### PR TITLE
Change GovUk (gov_uk) to Govuk (govuk)

### DIFF
--- a/lib/dfid-transition/patch/countries.rb
+++ b/lib/dfid-transition/patch/countries.rb
@@ -1,14 +1,14 @@
 require 'rest-client'
 require 'json'
 require 'dfid-transition/patch/base'
-require 'gov_uk/registers/country'
+require 'govuk/registers/country'
 
 module DfidTransition
   module Patch
     class Countries < Base
       def mutate_schema
         country_facet['allowed_values'] = transform_to_label_value(
-          GovUk::Registers::Country.countries)
+          Govuk::Registers::Country.countries)
       end
 
     private

--- a/lib/govuk/registers/country.rb
+++ b/lib/govuk/registers/country.rb
@@ -1,4 +1,4 @@
-module GovUk
+module Govuk
   class Registers
     class Country
       URL = 'https://country.register.gov.uk/records.json'.freeze

--- a/spec/lib/dfid/patch/countries_spec.rb
+++ b/spec/lib/dfid/patch/countries_spec.rb
@@ -60,7 +60,7 @@ describe DfidTransition::Patch::Countries do
         let(:all_countries) { json_for_page(1).concat(json_for_page(2)) }
 
         before do
-          allow(GovUk::Registers::Country).to receive(:countries).
+          allow(Govuk::Registers::Country).to receive(:countries).
             and_return(all_countries)
         end
 

--- a/spec/lib/govuk/registers/country.rb
+++ b/spec/lib/govuk/registers/country.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'gov_uk/registers/country'
+require 'govuk/registers/country'
 
-describe GovUk::Registers::Country do
+describe Govuk::Registers::Country do
   describe '.countries' do
     let(:query_results_p1)  { 'spec/fixtures/service-results/country-register-p1.json' }
     let(:query_results_p2)  { 'spec/fixtures/service-results/country-register-p2.json' }
@@ -12,13 +12,13 @@ describe GovUk::Registers::Country do
 
     it 'returns both active and inactive countries from the register' do
       allow(RestClient).to receive(:get).with(
-        GovUk::Registers::Country::URL,
+        Govuk::Registers::Country::URL,
         params: page(1)).and_return(File.read(query_results_p1))
       allow(RestClient).to receive(:get).with(
-        GovUk::Registers::Country::URL,
+        Govuk::Registers::Country::URL,
         params: page(2)).and_return(File.read(query_results_p2))
 
-      result = GovUk::Registers::Country.countries
+      result = Govuk::Registers::Country.countries
 
       expect(result.count).to eq 199
       expect(result).to include("serial-number" => 204,


### PR DESCRIPTION
I was mistaken about the standard module name for Govuk, which is
not, as I made @tahb use, `GovUk`, rather `Govuk`, with `govuk` rather
than `gov_uk` as a directory name.
