### PR TITLE
Sort countries in SPR schema

### DIFF
--- a/lib/dfid-transition/patch/specialist_publisher/countries.rb
+++ b/lib/dfid-transition/patch/specialist_publisher/countries.rb
@@ -8,10 +8,18 @@ module DfidTransition
       class Countries < Base
         def mutate_schema
           country_facet['allowed_values'] = transform_to_label_value(
-            Govuk::Registers::Country.countries)
+            alphabetically_sorted_countries)
         end
 
       private
+
+        def countries
+          Govuk::Registers::Country.countries
+        end
+
+        def alphabetically_sorted_countries
+          countries.sort_by { |_, details| details['name'] }
+        end
 
         def transform_to_label_value(query_results)
           query_results.map do |country_code, country_details|

--- a/spec/lib/dfid/patch/specialist_publisher/countries_spec.rb
+++ b/spec/lib/dfid/patch/specialist_publisher/countries_spec.rb
@@ -62,6 +62,13 @@ describe DfidTransition::Patch::SpecialistPublisher::Countries do
           )
         end
 
+        it 'sorts countries alphabetically by label' do
+          patcher.run
+
+          labels = country_facet['allowed_values'].map { |lv| lv['label'] }
+          expect(labels).to eql(labels.sort), 'country labels are not sorted'
+        end
+
         context 'the target schema file does not have a countries facet to patch' do
           let(:schema_src) { 'spec/fixtures/schemas/specialist_publisher/dfid_research_outputs_no_facets.json' }
 


### PR DESCRIPTION
When creating a new specialist document for DFID we would like our countries to be sorted by label (not by country code).

When viewing these same documents after publish we would like our filter options for country to also be sorted in this way.

To see these changes in the front end you'll need to:
- [reindex Rummager](https://github.com/alphagov/dfid-transition/wiki/AddingRummagerFieldTypes#command)
- [republish the Finders](https://github.com/alphagov/dfid-transition/wiki/Creating-a-New-Finder#publish-this-finder-upstream)
- [restart the stack using Bowl](https://github.com/alphagov/dfid-transition/wiki/Development-Setup#starting-with-bowler)
