### PR TITLE
Add Jenkins support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,7 @@ gem 'rdf-rdfxml'
 gem 'pry'
 gem 'nokogiri'
 
-group :development do
+group :development, :test do
   gem 'govuk-lint'
-end
-
-group :test do
   gem 'rspec'
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+export DISPLAY=:99
+export GOVUK_APP_DOMAIN=test.gov.uk
+export GOVUK_ASSET_ROOT=http://static.test.gov.uk
+export REPO_NAME="alphagov/dfid-transition"
+env
+
+function github_status {
+  REPO_NAME="$1"
+  STATUS="$2"
+  MESSAGE="$3"
+  gh-status "$REPO_NAME" "$GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" >/dev/null
+}
+
+function error_handler {
+  trap - ERR # disable error trap to avoid recursion.
+  local parent_lineno="$1"
+  local message="$2"
+  local code="${3:-1}"
+  if [[ -n "$message" ]] ; then
+    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
+  else
+    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
+  fi
+  github_status "$REPO_NAME" failure "failed on Jenkins"
+  exit "${code}"
+}
+
+trap "error_handler ${LINENO}" ERR
+github_status "$REPO_NAME" pending "is running on Jenkins"
+
+# Cleanup anything left from previous test runs
+git clean -fdx
+
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
+bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
+bundle exec rake
+
+export EXIT_STATUS=$?
+
+if [ "$EXIT_STATUS" == "0" ]; then
+  github_status "$REPO_NAME" success "succeeded on Jenkins"
+else
+  github_status "$REPO_NAME" failure "failed on Jenkins"
+fi
+
+exit $EXIT_STATUS
+


### PR DESCRIPTION
- Currently only running in a [branches job](https://ci.dev.publishing.service.gov.uk/job/dfid_transition_branches/)
- Needs hook support from this repo for branches to run a build automatically (no personal access)
- `jenkins.sh` copied and altered from [`govuk_content_schemas`](https://github.com/alphagov/govuk-content-schemas/blob/master/jenkins.sh)
