### PR TITLE
Convert abstract to markdown on import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'nokogiri'
 gem 'gds-api-adapters'
 gem 'govspeak'
 gem 'activesupport'
+gem 'kramdown'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,7 @@ DEPENDENCIES
   gds-api-adapters
   govspeak
   govuk-lint
+  kramdown
   nokogiri
   pry
   rake

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -11,6 +11,8 @@ module DfidTransition
 
   module Transform
     class Document
+      Html = DfidTransition::Transform::Html
+
       attr_reader :solution
       attr_accessor :content_id
 
@@ -36,7 +38,7 @@ module DfidTransition
 
       def title
         title = solution[:title].to_s
-        unescaped_title = DfidTransition::Transform::Html.unescape_three_times(title)
+        unescaped_title = Html.unescape_three_times(title)
         unescaped_title.strip
       end
 
@@ -84,8 +86,9 @@ module DfidTransition
       end
 
       def abstract
-        @abstract ||= DfidTransition::Transform::Html.unescape_three_times(
-          solution[:abstract].to_s)
+        @abstract ||= Html.to_markdown(
+          Html.unescape_three_times(solution[:abstract].to_s)
+        )
       end
 
       def body

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -92,11 +92,9 @@ module DfidTransition
       end
 
       def body
-        <<-MARKDOWN.strip_heredoc
-          ## Abstract
-
-          #{abstract}
-        MARKDOWN
+        "## Abstract"\
+        "\n"\
+        "#{abstract}"
       end
 
       def headers

--- a/lib/dfid-transition/transform/html.rb
+++ b/lib/dfid-transition/transform/html.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'kramdown'
+require 'nokogiri'
 
 module DfidTransition
   module Transform
@@ -13,7 +14,9 @@ module DfidTransition
       end
 
       def self.to_markdown(html)
-        kramdown_tree, _warnings = Kramdown::Parser::Html.parse(html)
+        corrected_html = Nokogiri::HTML.fragment(html).to_s
+
+        kramdown_tree, _warnings = Kramdown::Parser::Html.parse(corrected_html)
         Kramdown::Converter::Kramdown.convert(kramdown_tree).first
       end
     end

--- a/lib/dfid-transition/transform/html.rb
+++ b/lib/dfid-transition/transform/html.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require 'kramdown'
 
 module DfidTransition
   module Transform
@@ -9,6 +10,11 @@ module DfidTransition
             CGI.unescape_html(string_input)
           )
         )
+      end
+
+      def self.to_markdown(html)
+        kramdown_tree, _warnings = Kramdown::Parser::Html.parse(html)
+        Kramdown::Converter::Kramdown.convert(kramdown_tree).first
       end
     end
   end

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -20,7 +20,9 @@ module DfidTransition::Transform
           title:        literal(' &amp;#8216;And Then He Switched off the Phone&amp;#8217;: Mobile Phones ... '),
           abstract:     literal(
             '&amp;lt;p&amp;gt;This research design and methods paper can be '\
-            'applied to other countries in Africa and Latin America.&amp;lt;/p&amp;gt;'),
+            'applied to other countries in Africa and Latin America.'\
+            '&amp;lt;p&amp;gt;&amp;lt;ul&amp;gt;&amp;lt;li&amp;gt;Hello&amp;lt;/li&amp;gt;&amp;lt;/ul&amp;gt;&amp;lt;/p&amp;gt;'\
+            '&amp;lt;/p&amp;gt;'),
           countryCodes: literal('AZ GB')
         }
       end
@@ -127,6 +129,9 @@ module DfidTransition::Transform
         it 'has the abstract as markdown' do
           expect(body).to include('This research design and methods paper')
           expect(body).not_to include('<p>')
+        end
+        it 'corrects non-standard HTML – the list is separate' do
+          expect(body).to include("\n* Hello")
         end
       end
 

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -121,8 +121,8 @@ module DfidTransition::Transform
 
         it { is_expected.to be_a(String) }
 
-        it 'has a markdown h2 header for the abstract' do
-          expect(body).to include('## Abstract')
+        it 'has a header with no indents for the abstract' do
+          expect(body).to match(/^## Abstract/)
         end
         it 'has the abstract as markdown' do
           expect(body).to include('This research design and methods paper')

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -105,7 +105,7 @@ module DfidTransition::Transform
         end
       end
 
-      describe 'the metadata' do
+      describe '#metadata' do
         subject(:metadata) { doc.metadata }
 
         it 'has the document type' do
@@ -124,10 +124,9 @@ module DfidTransition::Transform
         it 'has a markdown h2 header for the abstract' do
           expect(body).to include('## Abstract')
         end
-        it 'has the abstract' do
-          expect(body).to include(
-            '<p>This research design and methods paper '\
-            'can be applied to other countries in Africa and Latin America.</p>')
+        it 'has the abstract as markdown' do
+          expect(body).to include('This research design and methods paper')
+          expect(body).not_to include('<p>')
         end
       end
 

--- a/spec/lib/dfid-transition/transform/html_spec.rb
+++ b/spec/lib/dfid-transition/transform/html_spec.rb
@@ -1,37 +1,91 @@
 require 'spec_helper'
 require 'dfid-transition/transform/html'
+require 'active_support/core_ext/string/strip'
 
 module DfidTransition::Transform
   describe Html do
-    subject(:unescaped_html) do
-      DfidTransition::Transform::Html.unescape_three_times(string_input)
-    end
-
-    context 'HTML is single-escaped' do
-      let(:string_input) { '&lt;p&gt;hello&lt;/p&gt;' }
-      it { is_expected.to eql('<p>hello</p>') }
-    end
-
-    context 'HTML is double-escaped' do
-      context 'There are special character encodes' do
-        let(:string_input) { '&amp;#8216;Successful&amp;#8217; Development Models' }
-        it { is_expected.to eql('‘Successful’ Development Models') }
+    describe '.unescaped_html' do
+      subject(:unescaped_html) do
+        DfidTransition::Transform::Html.unescape_three_times(string_input)
       end
-      context 'There are double-escaped tags' do
-        let(:string_input) { '&amp;lt;br/&amp;gt;&amp;lt;br/&amp;gt; This policy brief explores' }
-        it { is_expected.to eql('<br/><br/> This policy brief explores') }
+
+      context 'HTML is single-escaped' do
+        let(:string_input) { '&lt;p&gt;hello&lt;/p&gt;' }
+        it { is_expected.to eql('<p>hello</p>') }
       end
-      context 'there are unmatched tags' do
-        let(:string_input) { 'domestic violence.&amp;lt;/p&amp;gt;' }
-        it 'does not care' do
-          expect(unescaped_html).to eql('domestic violence.</p>')
+
+      context 'HTML is double-escaped' do
+        context 'There are special character encodes' do
+          let(:string_input) { '&amp;#8216;Successful&amp;#8217; Development Models' }
+          it { is_expected.to eql('‘Successful’ Development Models') }
+        end
+        context 'There are double-escaped tags' do
+          let(:string_input) { '&amp;lt;br/&amp;gt;&amp;lt;br/&amp;gt; This policy brief explores' }
+          it { is_expected.to eql('<br/><br/> This policy brief explores') }
+        end
+        context 'there are unmatched tags' do
+          let(:string_input) { 'domestic violence.&amp;lt;/p&amp;gt;' }
+          it 'does not care' do
+            expect(unescaped_html).to eql('domestic violence.</p>')
+          end
         end
       end
+
+      context 'HTML is triple-escaped' do
+        let(:string_input) { 'spread of India&amp;amp;#8217;s HIV epidemic' }
+        it { is_expected.to eql('spread of India’s HIV epidemic') }
+      end
     end
 
-    context 'HTML is triple-escaped' do
-      let(:string_input) { 'spread of India&amp;amp;#8217;s HIV epidemic' }
-      it { is_expected.to eql('spread of India’s HIV epidemic') }
+    describe '.to_markdown' do
+      subject(:markdown) do
+        DfidTransition::Transform::Html.to_markdown(string_input)
+      end
+
+      context 'Everything is peachy' do
+        let(:string_input) do
+          <<-HTML.strip_heredoc
+            <p>This is para 1</p>
+            <p>This is para 2</p>
+            <ul>
+              <li>A list item</li>
+            </ul>
+          HTML
+        end
+        it {
+          is_expected.to eql(<<-MARKDOWN.strip_heredoc
+            This is para 1
+
+            This is para 2
+
+            * A list item
+
+            MARKDOWN
+          )
+        }
+      end
+
+      context 'there are lists in paragraphs' do
+        let(:string_input) do
+          <<-HTML.strip_heredoc
+            <p>This is a para. Lists should not appear here,
+               because an HTML parser will close the 'p' tag
+               to cope, leaving a trailing 'p'.
+               Oh dear!
+
+               <ul>
+                 <li>BOING</li>
+                 <li>BOING</li>
+               </ul>
+            </p>
+          HTML
+        end
+
+        it 'deals with the problem as part of the conversion' do
+          expect(markdown).to include('This is a para. Lists should not appear')
+          expect(markdown).to include("BOING\n* BOING")
+        end
+      end
     end
   end
 end

--- a/spec/lib/dfid-transition/transform/html_spec.rb
+++ b/spec/lib/dfid-transition/transform/html_spec.rb
@@ -6,7 +6,7 @@ module DfidTransition::Transform
   describe Html do
     describe '.unescaped_html' do
       subject(:unescaped_html) do
-        DfidTransition::Transform::Html.unescape_three_times(string_input)
+        Html.unescape_three_times(string_input)
       end
 
       context 'HTML is single-escaped' do
@@ -39,7 +39,7 @@ module DfidTransition::Transform
 
     describe '.to_markdown' do
       subject(:markdown) do
-        DfidTransition::Transform::Html.to_markdown(string_input)
+        Html.to_markdown(string_input)
       end
 
       context 'Everything is peachy' do
@@ -81,9 +81,9 @@ module DfidTransition::Transform
           HTML
         end
 
-        it 'deals with the problem as part of the conversion' do
+        it 'expands the list and closes the para beforehand. A newline separates' do
           expect(markdown).to include('This is a para. Lists should not appear')
-          expect(markdown).to include("BOING\n* BOING")
+          expect(markdown).to include("\n* BOING\n* BOING")
         end
       end
     end


### PR DESCRIPTION
We were previously preserving HTML from r4d, with two downsides:
- The HTML was sometimes invalid
- Editors would see HTML, not markdown

Deal with both downsides at the same time – by converting to
markdown, bad HTML is turned into "best-guess" markdown. So, for
example, block-level elements inside inline elements (like lists in &lt;p&gt; tags in
http://linked-development.org/r4d/output/202401/) will be turned into
usable content.
