### PR TITLE
Add authors to research output body

### DIFF
--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -10,21 +10,24 @@ module DfidTransition
           PREFIX dcterms: <http://purl.org/dc/terms/>
           PREFIX ont:     <http://purl.org/ontology/bibo/>
           PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
+          PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
 
           SELECT DISTINCT ?output ?date ?abstract
+                          (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
                           (GROUP_CONCAT(DISTINCT(?titleSource)) AS ?title)
                           (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
           WHERE {
             ?output a ont:Article ;
                     dcterms:title ?titleSource ;
                     dcterms:abstract ?abstract ;
-                    dcterms:date ?date ;
-                    dcterms:coverage ?country .
-            ?country a geo:self_governing ;
-                     geo:codeISO2 ?codeISO2 .
+                    dcterms:date ?date .
+
+            OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
+            OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
+
           } GROUP BY ?output ?date ?abstract
           ORDER BY DESC(?date)
-          LIMIT 10
+          LIMIT 20
         SPARQL
 
         def endpoint

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -82,6 +82,10 @@ module DfidTransition
         }]
       end
 
+      def creators
+        solution[:creators].to_s.split('|').map(&:strip)
+      end
+
       def details
         {
           body: Govuk::Presenters::Govspeak.present(body),
@@ -100,9 +104,10 @@ module DfidTransition
       end
 
       def body
-        "## Abstract"\
-        "\n"\
-        "#{abstract}"
+        "## Authors\n\n"\
+        "#{creators.map { |name| "* #{name}" }.join("\n")}\n\n"\
+        "## Abstract\n"\
+        "#{abstract}\n"
       end
 
       def headers

--- a/spec/fixtures/service-results/research-outputs-sparql.json
+++ b/spec/fixtures/service-results/research-outputs-sparql.json
@@ -1,6 +1,6 @@
 {
   "head": {
-    "vars": [ "output" , "date" , "abstract" , "title" , "countryCodes" ]
+    "vars": [ "output" , "date" , "abstract" , "creators" , "title" , "countryCodes" ]
   } ,
   "results": {
     "bindings": [
@@ -8,6 +8,7 @@
         "output": { "type": "uri" , "value": "http://linked-development.org/r4d/output/213014/" } ,
         "date": { "type": "literal" , "value": "2016-04-28T11:26:00" } ,
         "abstract": { "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral" , "type": "typed-literal" , "value": " - " } ,
+        "creators": { "type": "literal" , "value": " Humble, S. " } ,
         "title": { "type": "literal" , "value": " In Search of Human Capital - Identifying Gifted Children in Poor Areas of Dar Es Salaam, Tanzania " } ,
         "countryCodes": { "type": "literal" , "value": "TZ" }
       } ,
@@ -15,6 +16,7 @@
         "output": { "type": "uri" , "value": "http://linked-development.org/r4d/output/213009/" } ,
         "date": { "type": "literal" , "value": "2016-04-28T09:52:00" } ,
         "abstract": { "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral" , "type": "typed-literal" , "value": " The Study aims to deepen understanding of why investments in Domestic Violence law (DV Law) are faltering and what can be done. " } ,
+        "creators": { "type": "literal" , "value": " Brickell, K. | Baureaksmey Prak. | Bunnak Poch. " } ,
         "title": { "type": "literal" , "value": " Domestic Violence Law: The Gap Between Legislation and Practice in Cambodia and What Can Be Done About It " } ,
         "countryCodes": { "type": "literal" , "value": "KH" }
       }

--- a/spec/lib/dfid-transition/extract/query/outputs_spec.rb
+++ b/spec/lib/dfid-transition/extract/query/outputs_spec.rb
@@ -28,11 +28,16 @@ describe DfidTransition::Extract::Query::Outputs do
       end
     end
 
-    describe 'the first solution' do
-      subject(:solution) { query.solutions.first }
+    describe 'the last solution' do
+      subject(:solution) { query.solutions.last }
 
       it 'has an output URI' do
         expect(solution[:output]).to be_an(RDF::URI)
+      end
+
+      it 'has a pipe-delimited list of creators' do
+        expect(solution[:creators]).to be_an(RDF::Literal)
+        expect(solution[:creators].to_s).to include(' | ')
       end
     end
   end

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -18,6 +18,7 @@ module DfidTransition::Transform
           output:       uri(original_url),
           date:         literal('2016-04-28T09:52:00'),
           title:        literal(' &amp;#8216;And Then He Switched off the Phone&amp;#8217;: Mobile Phones ... '),
+          creators:     literal(' Heinlein, R. | Asimov, A. '),
           abstract:     literal(
             '&amp;lt;p&amp;gt;This research design and methods paper can be '\
             'applied to other countries in Africa and Latin America.'\
@@ -143,6 +144,13 @@ module DfidTransition::Transform
         it 'has a header with no indents for the abstract' do
           expect(body).to match(/^## Abstract/)
         end
+        it 'has a header with no indents for the creators' do
+          expect(body).to match(/^## Authors/)
+        end
+        it 'has a list for the creators' do
+          expect(body).to include('* Heinlein, R.')
+          expect(body).to include('* Asimov, A.')
+        end
         it 'has the abstract as markdown' do
           expect(body).to include('This research design and methods paper')
           expect(body).not_to include('<p>')
@@ -150,6 +158,12 @@ module DfidTransition::Transform
         it 'corrects non-standard HTML – the list is separate' do
           expect(body).to include("\n* Hello")
         end
+      end
+
+      describe '#creators' do
+        subject(:creators) { doc.creators }
+
+        it { is_expected.to eql(['Heinlein, R.', 'Asimov, A.']) }
       end
 
       describe '#headers' do


### PR DESCRIPTION
- Comes with its own top-level header
- Renders as a list
- In the SPARQL query:
  - Start to use property paths in the query apropos of the fact that
    creators use bnodes for uniqueness (authors that are distinct but
    have no URL). As a result, only countries have an ISO2 code, so we
    can drop the `self_governing` type check for an intermediate bound
    `?country` variable, which helps speed things up
  - make sure that `OPTIONAL` things are really `OPTIONAL` (previously we
    were only retrieving outputs with a `self_governing` country – think `LEFT JOIN`, SPARQL
    newcomers)
  - Pack authors as a pipe-delimited list

![screen shot 2016-05-19 at 09 36 36](https://cloud.githubusercontent.com/assets/194511/15387480/4012317c-1da5-11e6-8e07-89b6c0f31ef2.png)
