### PR TITLE
Ensure a change history is sent on import

### DIFF
--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -74,11 +74,18 @@ module DfidTransition
         [ORGANISATION_CONTENT_ID]
       end
 
+      def change_history
+        [{
+          public_timestamp: public_updated_at,
+          note:             'First published.'
+        }]
+      end
+
       def details
         {
           body: Govuk::Presenters::Govspeak.present(body),
-          metadata: metadata
-          # change_history: change_history
+          metadata: metadata,
+          change_history: change_history
         }.tap do |details_hash|
           details_hash[:headers] = headers
           #  details_hash[:attachments] = attachments if document.attachments

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -96,6 +96,11 @@ module DfidTransition::Transform
           expect(details[:metadata]).to eql(doc.metadata)
         end
 
+        it 'has a non-empty change history list' do
+          expect(details[:change_history]).to be_an(Array)
+          expect(details[:change_history]).not_to be_empty
+        end
+
         describe 'the presented body' do
           subject(:presented_body) { details[:body] }
 
@@ -116,6 +121,15 @@ module DfidTransition::Transform
         it 'has a list of countries' do
           expect(metadata[:country]).to eql(%w(AZ GB))
         end
+      end
+
+      describe '#change_history' do
+        subject(:change_history) { doc.change_history }
+
+        it {
+          is_expected.to eql \
+            [{ public_timestamp: doc.public_updated_at, note: 'First published.' }]
+        }
       end
 
       describe '#body' do


### PR DESCRIPTION
Otherwise, a 500 will be caused in specialist-publisher-rebuild when
editing the document.
