### PR TITLE
Only use broader themes patching SPR

### DIFF
--- a/lib/dfid-transition/extract/query/base.rb
+++ b/lib/dfid-transition/extract/query/base.rb
@@ -14,6 +14,10 @@ module DfidTransition
       end
 
       class Base
+        def initialize(client = nil)
+          @client = client
+        end
+
         def query
           raise NotImplementedError
         end

--- a/lib/dfid-transition/extract/query/themes.rb
+++ b/lib/dfid-transition/extract/query/themes.rb
@@ -1,0 +1,25 @@
+require 'dfid-transition/extract/query/base'
+
+module DfidTransition
+  module Extract
+    module Query
+      class Themes < Base
+        QUERY = <<-SPARQL.freeze
+          PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+          SELECT DISTINCT ?theme ?prefLabel
+          WHERE {
+            ?theme skos:inScheme <http://r4d.dfid.gov.uk/rdf/skos/Themes> ;
+              skos:prefLabel ?prefLabel ;
+              skos:narrower ?narrower .
+          }
+          ORDER BY ?prefLabel
+        SPARQL
+
+        def query
+          QUERY
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/patch/govuk_content_schemas/base.rb
+++ b/lib/dfid-transition/patch/govuk_content_schemas/base.rb
@@ -1,0 +1,24 @@
+require 'dfid-transition/patch/patcher'
+require 'json'
+
+module DfidTransition
+  module Patch
+    module GovukContentSchemas
+      class Base < Patcher
+
+      private
+
+        def relative_path
+          File.expand_path(
+            File.join(
+              Dir.pwd,
+              '..',
+              'govuk_content_schemas',
+              'formats/specialist_document/publisher/details.json'
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/patch/govuk_content_schemas/themes.rb
+++ b/lib/dfid-transition/patch/govuk_content_schemas/themes.rb
@@ -8,7 +8,7 @@ module DfidTransition
         include DfidTransition::Transform::Themes
 
         def mutate_schema
-          dfid_properties['theme'] = {
+          dfid_properties['dfid_theme'] = {
             'type': 'array',
             'enum': theme_identifiers
           }

--- a/lib/dfid-transition/patch/govuk_content_schemas/themes.rb
+++ b/lib/dfid-transition/patch/govuk_content_schemas/themes.rb
@@ -1,0 +1,35 @@
+require 'dfid-transition/transform/themes'
+require 'dfid-transition/patch/govuk_content_schemas/base'
+
+module DfidTransition
+  module Patch
+    module GovukContentSchemas
+      class Themes < Base
+        include DfidTransition::Transform::Themes
+
+        def mutate_schema
+          dfid_properties['theme'] = {
+            'type': 'array',
+            'enum': theme_identifiers
+          }
+        end
+
+        private
+
+        def theme_identifiers
+          themes_query.solutions.map do |solution|
+            parameterize(solution[:theme].to_s)
+          end
+        end
+
+        def dfid_properties
+          schema_hash.dig(*%w(
+            definitions
+            dfid_research_output_metadata
+            properties
+          ))
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/patch/rummager/themes.rb
+++ b/lib/dfid-transition/patch/rummager/themes.rb
@@ -17,10 +17,6 @@ module DfidTransition
 
       private
 
-        def themes_query
-          @themes_query ||= DfidTransition::Extract::Query::Themes.new
-        end
-
         def add_theme_field
           unless schema_hash.fetch('fields').include?('theme')
             schema_hash.fetch('fields') << 'theme'

--- a/lib/dfid-transition/patch/rummager/themes.rb
+++ b/lib/dfid-transition/patch/rummager/themes.rb
@@ -1,4 +1,6 @@
+require 'dfid-transition/extract/query/themes'
 require 'dfid-transition/patch/rummager/base'
+require 'dfid-transition/transform/themes'
 require 'govuk/registers/country'
 require 'rest-client'
 
@@ -6,10 +8,28 @@ module DfidTransition
   module Patch
     module Rummager
       class Themes < Base
+        include DfidTransition::Transform::Themes
+
         def mutate_schema
+          add_theme_field
+          add_theme_expansions
+        end
+
+      private
+
+        def themes_query
+          @themes_query ||= DfidTransition::Extract::Query::Themes.new
+        end
+
+        def add_theme_field
           unless schema_hash.fetch('fields').include?('theme')
             schema_hash.fetch('fields') << 'theme'
           end
+        end
+
+        def add_theme_expansions
+          schema_hash['expanded_search_result_fields']['theme'] =
+            transform_to_label_value(themes_query.solutions)
         end
       end
     end

--- a/lib/dfid-transition/patch/rummager/themes.rb
+++ b/lib/dfid-transition/patch/rummager/themes.rb
@@ -18,13 +18,13 @@ module DfidTransition
       private
 
         def add_theme_field
-          unless schema_hash.fetch('fields').include?('theme')
-            schema_hash.fetch('fields') << 'theme'
+          unless schema_hash.fetch('fields').include?('dfid_theme')
+            schema_hash.fetch('fields') << 'dfid_theme'
           end
         end
 
         def add_theme_expansions
-          schema_hash['expanded_search_result_fields']['theme'] =
+          schema_hash['expanded_search_result_fields']['dfid_theme'] =
             transform_to_label_value(themes_query.solutions)
         end
       end

--- a/lib/dfid-transition/patch/specialist_publisher/themes.rb
+++ b/lib/dfid-transition/patch/specialist_publisher/themes.rb
@@ -15,7 +15,7 @@ module DfidTransition
       private
 
         def theme_facet
-          facet('theme')
+          facet('dfid_theme')
         end
       end
     end

--- a/lib/dfid-transition/patch/specialist_publisher/themes.rb
+++ b/lib/dfid-transition/patch/specialist_publisher/themes.rb
@@ -1,4 +1,3 @@
-require 'dfid-transition/extract/query/themes'
 require 'dfid-transition/transform/themes'
 require 'dfid-transition/patch/specialist_publisher/base'
 
@@ -14,10 +13,6 @@ module DfidTransition
         end
 
       private
-
-        def themes_query
-          @themes_query ||= DfidTransition::Extract::Query::Themes.new
-        end
 
         def theme_facet
           facet('theme')

--- a/lib/dfid-transition/patch/specialist_publisher/themes.rb
+++ b/lib/dfid-transition/patch/specialist_publisher/themes.rb
@@ -7,12 +7,13 @@ module DfidTransition
     module SpecialistPublisher
       class Themes < Base
         QUERY = <<-SPARQL.freeze
-          PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+          PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
           SELECT DISTINCT ?theme ?prefLabel
           WHERE {
             ?theme skos:inScheme <http://r4d.dfid.gov.uk/rdf/skos/Themes> ;
-                   skos:prefLabel ?prefLabel .
+              skos:prefLabel ?prefLabel ;
+              skos:narrower ?narrower .
           }
           ORDER BY ?prefLabel
         SPARQL

--- a/lib/dfid-transition/patch/specialist_publisher/themes.rb
+++ b/lib/dfid-transition/patch/specialist_publisher/themes.rb
@@ -1,12 +1,13 @@
 require 'dfid-transition/extract/query/themes'
+require 'dfid-transition/transform/themes'
 require 'dfid-transition/patch/specialist_publisher/base'
-require 'sparql'
-require 'rdf/rdfxml'
 
 module DfidTransition
   module Patch
     module SpecialistPublisher
       class Themes < Base
+        include DfidTransition::Transform::Themes
+
         def mutate_schema
           theme_facet['allowed_values'] =
             transform_to_label_value(themes_query.solutions)
@@ -20,24 +21,6 @@ module DfidTransition
 
         def theme_facet
           facet('theme')
-        end
-
-        def transform_to_label_value(r4d_solutions)
-          r4d_solutions.map do |solution|
-            theme_slug = parameterize(solution['theme'].to_s)
-
-            {
-              value: theme_slug,
-              label: solution['prefLabel'].to_s
-            }
-          end
-        end
-
-        def parameterize(theme_url)
-          theme_url.
-            sub(%r{http://.*#}, '').  # Strip http://....#
-            gsub('%20', '_').         # underscore escaped spaces
-            downcase
         end
       end
     end

--- a/lib/dfid-transition/transform/themes.rb
+++ b/lib/dfid-transition/transform/themes.rb
@@ -1,0 +1,24 @@
+module DfidTransition
+  module Transform
+    module Themes
+      def transform_to_label_value(r4d_solutions)
+        r4d_solutions.map do |solution|
+          theme_slug = parameterize(solution['theme'].to_s)
+
+          {
+            value: theme_slug,
+            label: solution['prefLabel'].to_s
+          }
+        end
+      end
+
+      def parameterize(theme_url)
+        theme_url.
+          sub(%r{http://.*#}, ''). # Strip http://....#
+        gsub('%20', '_').          # underscore escaped spaces
+        downcase
+      end
+    end
+  end
+end
+

--- a/lib/dfid-transition/transform/themes.rb
+++ b/lib/dfid-transition/transform/themes.rb
@@ -1,6 +1,16 @@
+require 'dfid-transition/extract/query/themes'
+
 module DfidTransition
   module Transform
+    ##
+    # For patchers that need to query themes and transform those
+    # values
+    #
     module Themes
+      def themes_query
+        @themes_query ||= DfidTransition::Extract::Query::Themes.new
+      end
+
       def transform_to_label_value(r4d_solutions)
         r4d_solutions.map do |solution|
           theme_slug = parameterize(solution['theme'].to_s)

--- a/lib/tasks/patch/themes.rake
+++ b/lib/tasks/patch/themes.rake
@@ -1,10 +1,12 @@
 require 'dfid-transition/patch/specialist_publisher/themes'
 require 'dfid-transition/patch/rummager/themes'
+require 'dfid-transition/patch/govuk_content_schemas/themes'
 
 namespace :patch do
   desc 'Patch the DFID schema with themes from the R4D SKOS'
   task :themes do
     DfidTransition::Patch::SpecialistPublisher::Themes.new.run
     DfidTransition::Patch::Rummager::Themes.new.run
+    DfidTransition::Patch::GovukContentSchemas::Themes.new.run
   end
 end

--- a/spec/fixtures/schemas/govuk_content_schemas/details_src.json
+++ b/spec/fixtures/schemas/govuk_content_schemas/details_src.json
@@ -1,0 +1,1196 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "body",
+    "metadata",
+    "change_history"
+  ],
+  "properties": {
+    "body": {
+      "$ref" : "#/definitions/multiple_content_types"
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/asset_link"
+      }
+    },
+    "metadata": {
+      "$ref": "#/definitions/any_metadata"
+    },
+    "max_cache_time": {
+      "description": "The maximum length of time the content should be cached, in seconds.",
+      "type": "integer"
+    },
+    "headers" : {
+      "$ref": "#/definitions/nested_headers"
+    },
+    "change_history": {
+      "$ref": "#/definitions/change_history"
+    }
+  },
+  "definitions": {
+    "any_metadata": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/aaib_report_metadata" },
+        { "$ref": "#/definitions/asylum_support_decision_metadata" },
+        { "$ref": "#/definitions/cma_case_metadata" },
+        { "$ref": "#/definitions/countryside_stewardship_grant_metadata" },
+        { "$ref": "#/definitions/dfid_research_output_metadata" },
+        { "$ref": "#/definitions/drug_safety_update_metadata" },
+        { "$ref": "#/definitions/employment_appeal_tribunal_decision_metadata" },
+        { "$ref": "#/definitions/employment_tribunal_decision_metadata" },
+        { "$ref": "#/definitions/european_structural_investment_fund_metadata" },
+        { "$ref": "#/definitions/international_development_fund_metadata" },
+        { "$ref": "#/definitions/maib_report_metadata" },
+        { "$ref": "#/definitions/medical_safety_alert_metadata" },
+        { "$ref": "#/definitions/raib_report_metadata" },
+        { "$ref": "#/definitions/tax_tribunal_decision_metadata" },
+        { "$ref": "#/definitions/utaac_decision_metadata" },
+        { "$ref": "#/definitions/vehicle_recalls_and_faults_alert_metadata" }
+      ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "text", "level", "id"
+        ],
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          }
+        }
+      }
+    },
+    "aaib_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "aaib_report"
+          ]
+        },
+        "aircraft_category": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "commercial-fixed-wing",
+              "commercial-rotorcraft",
+              "general-aviation-fixed-wing",
+              "general-aviation-rotorcraft",
+              "sport-aviation-and-balloons"
+            ]
+          }
+        },
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "annual-safety-report",
+            "correspondence-investigation",
+            "field-investigation",
+            "pre-1997-monthly-report",
+            "foreign-report",
+            "formal-report",
+            "special-bulletin",
+            "safety-study"
+          ]
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "aircraft_type": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "registration": {
+          "type": "string"
+        }
+      }
+    },
+    "asylum_support_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "asylum_support_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_category": {
+          "type": "string"
+        },
+        "tribunal_decision_sub_category": {
+          "type": "string"
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "not-landmark",
+            "landmark"
+          ]
+        },
+        "tribunal_decision_reference_number": {
+          "type": "string"
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "cma_case_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "cma_case"
+          ]
+        },
+        "case_type": {
+          "type": "string",
+          "enum": [
+            "ca98-and-civil-cartels",
+            "criminal-cartels",
+            "markets",
+            "mergers",
+            "consumer-enforcement",
+            "regulatory-references-and-appeals",
+            "review-of-orders-and-undertakings"
+          ]
+        },
+        "case_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "market_sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "aerospace",
+              "agriculture-environment-and-natural-resources",
+              "building-and-construction",
+              "chemicals",
+              "clothing-footwear-and-fashion",
+              "communications",
+              "defence",
+              "distribution-and-service-industries",
+              "electronics-industry",
+              "energy",
+              "engineering",
+              "financial-services",
+              "fire-police-and-security",
+              "food-manufacturing",
+              "giftware-jewellery-and-tableware",
+              "healthcare-and-medical-equipment",
+              "household-goods-furniture-and-furnishings",
+              "mineral-extraction-mining-and-quarrying",
+              "motor-industry",
+              "oil-and-gas-refining-and-petrochemicals",
+              "paper-printing-and-packaging",
+              "pharmaceuticals",
+              "public-markets",
+              "recreation-and-leisure",
+              "retail-and-wholesale",
+              "telecommunications",
+              "textiles",
+              "transport",
+              "utilities"
+            ]
+          }
+        },
+        "outcome_type": {
+          "type": "string",
+          "enum": [
+            "ca98-no-grounds-for-action-non-infringement",
+            "ca98-infringement-chapter-i",
+            "ca98-infringement-chapter-ii",
+            "ca98-administrative-priorities",
+            "ca98-commitment",
+            "criminal-cartels-verdict",
+            "markets-phase-1-no-enforcement-action",
+            "markets-phase-1-undertakings-in-lieu-of-reference",
+            "markets-phase-1-referral",
+            "mergers-phase-1-clearance",
+            "mergers-phase-1-clearance-with-undertakings-in-lieu",
+            "mergers-phase-1-referral",
+            "mergers-phase-1-found-not-to-qualify",
+            "mergers-phase-1-public-interest-interventions",
+            "markets-phase-2-clearance-no-adverse-effect-on-competition",
+            "markets-phase-2-adverse-effect-on-competition-leading-to-remedies",
+            "markets-phase-2-decision-to-dispense-with-procedural-obligations",
+            "mergers-phase-2-clearance",
+            "mergers-phase-2-clearance-with-remedies",
+            "mergers-phase-2-prohibition",
+            "mergers-phase-2-cancellation",
+            "consumer-enforcement-no-action",
+            "consumer-enforcement-court-order",
+            "consumer-enforcement-undertakings",
+            "consumer-enforcement-changes-to-business-practices-agreed",
+            "regulatory-references-and-appeals-final-determination"
+          ]
+        },
+        "opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "closed_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "dfid_research_output_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "dfid_research_output"
+          ]
+        },
+        "dfid_review_status": {
+          "type": "string",
+          "enum": [
+            "unreviewed",
+            "peer_reviewed"
+          ]
+        },
+        "country": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AF",
+              "AL",
+              "DZ",
+              "AD",
+              "AO",
+              "AG",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "BD",
+              "BB",
+              "BY",
+              "BE",
+              "BZ",
+              "BJ",
+              "BT",
+              "BO",
+              "BA",
+              "BW",
+              "BR",
+              "BN",
+              "BG",
+              "BF",
+              "MM",
+              "BI",
+              "KH",
+              "CM",
+              "CA",
+              "CV",
+              "CF",
+              "TD",
+              "CL",
+              "CN",
+              "CO",
+              "KM",
+              "CG",
+              "CD",
+              "CR",
+              "HR",
+              "CU",
+              "CY",
+              "CZ",
+              "CS",
+              "DK",
+              "DJ",
+              "DM",
+              "DO",
+              "DD",
+              "TL",
+              "EC",
+              "EG",
+              "SV",
+              "GQ",
+              "ER",
+              "EE",
+              "ET",
+              "FJ",
+              "FI",
+              "FR",
+              "GA",
+              "GE",
+              "DE",
+              "GH",
+              "GR",
+              "GD",
+              "GT",
+              "GN",
+              "GW",
+              "GY",
+              "HT",
+              "HN",
+              "HU",
+              "IS",
+              "IN",
+              "ID",
+              "IR",
+              "IQ",
+              "IE",
+              "IL",
+              "IT",
+              "CI",
+              "JM",
+              "JP",
+              "JO",
+              "KZ",
+              "KE",
+              "KI",
+              "XK",
+              "KW",
+              "KG",
+              "LA",
+              "LV",
+              "LB",
+              "LS",
+              "LR",
+              "LY",
+              "LI",
+              "LT",
+              "LU",
+              "MK",
+              "MG",
+              "MW",
+              "MY",
+              "MV",
+              "ML",
+              "MT",
+              "MH",
+              "MR",
+              "MU",
+              "MX",
+              "FM",
+              "MD",
+              "MC",
+              "MN",
+              "ME",
+              "MA",
+              "MZ",
+              "NA",
+              "NR",
+              "NP",
+              "NL",
+              "NZ",
+              "NI",
+              "NE",
+              "NG",
+              "KP",
+              "NO",
+              "OM",
+              "PK",
+              "PW",
+              "PA",
+              "PG",
+              "PY",
+              "PE",
+              "PH",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "WS",
+              "SM",
+              "ST",
+              "SA",
+              "SN",
+              "RS",
+              "SC",
+              "SL",
+              "SG",
+              "SK",
+              "SI",
+              "SB",
+              "SO",
+              "ZA",
+              "KR",
+              "SS",
+              "ES",
+              "LK",
+              "KN",
+              "LC",
+              "VC",
+              "SD",
+              "SR",
+              "SZ",
+              "SE",
+              "CH",
+              "SY",
+              "TJ",
+              "TZ",
+              "TH",
+              "BS",
+              "GM",
+              "TG",
+              "TO",
+              "TT",
+              "TN",
+              "TR",
+              "TM",
+              "TV",
+              "SU",
+              "UG",
+              "UA",
+              "AE",
+              "GB",
+              "US",
+              "UY",
+              "UZ",
+              "VU",
+              "VA",
+              "VE",
+              "VN",
+              "YE",
+              "YU",
+              "ZM",
+              "ZW"
+            ]
+          }
+        },
+        "dfid_authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "countryside_stewardship_grant_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "countryside_stewardship_grant"
+          ]
+        },
+        "grant_type": {
+          "type": "string",
+          "enum": [
+            "option",
+            "capital-item",
+            "supplement"
+          ]
+        },
+        "land_use": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "arable-land",
+              "boundaries",
+              "coast",
+              "educational-access",
+              "flood-risk",
+              "grassland",
+              "historic-environment",
+              "livestock-management",
+              "organic-land",
+              "priority-habitats",
+              "trees-non-woodland",
+              "uplands",
+              "vegetation-control",
+              "water-quality",
+              "wildlife-package",
+              "woodland"
+            ]
+          }
+        },
+        "tiers_or_standalone_items": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "higher-tier",
+              "mid-tier",
+              "standalone-capital-items"
+            ]
+          }
+        },
+        "funding_amount": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "up-to-100",
+              "101-to-200",
+              "201-to-300",
+              "301-to-400",
+              "401-to-500",
+              "more-than-500",
+              "up-to-50-actual-costs",
+              "more-than-50-actual-costs"
+            ]
+          }
+        }
+      }
+    },
+    "drug_safety_update_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "drug_safety_update"
+          ]
+        },
+        "therapeutic_area": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "anaesthesia-intensive-care",
+              "cancer",
+              "cardiovascular-disease-lipidology",
+              "dentistry",
+              "dermatology",
+              "ear-nose-throat",
+              "endocrinology-diabetology-metabolism",
+              "gi-hepatology-pancreatic-disorders",
+              "haematology",
+              "immunology-vaccination",
+              "immunosuppression-transplantation",
+              "infectious-disease",
+              "neurology",
+              "nutrition-dietetics",
+              "obstetrics-gynaecology-fertility",
+              "ophthalmology",
+              "paediatrics-neonatology",
+              "pain-management-palliation",
+              "psychiatry",
+              "radiology-imaging",
+              "respiratory-disease-allergy",
+              "rheumatology",
+              "urology-nephrology"
+            ]
+          }
+        },
+        "first_published_at": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_appeal_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_appeal_tribunal_decision"
+          ]
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_landmark": {
+          "type": "string",
+          "enum": [
+            "landmark",
+            "not-landmark"
+          ]
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "employment_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "employment_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_country": {
+          "type": "string",
+          "enum": [
+            "england-and-wales",
+            "scotland"
+          ]
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "european_structural_investment_fund_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "esi_fund"
+          ]
+        },
+        "fund_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "fund_type": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "access-to-work",
+              "business-support",
+              "climate-change",
+              "environment",
+              "it-and-broadband",
+              "learning-and-skills",
+              "low-carbon",
+              "renewable-energy",
+              "research-and-innovation",
+              "social-inclusion",
+              "transport",
+              "techincal-assistance",
+              "tourism"
+            ]
+          }
+        },
+        "location": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "north-east",
+              "north-west",
+              "yorkshire-and-humber",
+              "east-midlands",
+              "west-midlands",
+              "east-of-england",
+              "south-east",
+              "south-west",
+              "london"
+            ]
+          }
+        },
+        "funding_source": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "european-social-fund",
+              "european-regional-development-fund",
+              "european-agricoltural-fund-for-rural"
+            ]
+          }
+        },
+        "closing_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "international_development_fund_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "international_development_fund"
+          ]
+        },
+        "fund_state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ]
+        },
+        "location": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "afghanistan",
+              "bangladesh",
+              "burma",
+              "democratic-republic-of-congo",
+              "ethiopia",
+              "ghana",
+              "india",
+              "kenya",
+              "kyrgyzstan",
+              "liberia",
+              "malawi",
+              "mozambique",
+              "nepal",
+              "nigeria",
+              "the-occupied-palestinian-territories",
+              "pakistan",
+              "rwanda",
+              "sierra-leone",
+              "somalia",
+              "south-africa",
+              "sudan",
+              "south-sudan",
+              "tajikistan",
+              "tanzania",
+              "uganda",
+              "yemen",
+              "zambia",
+              "zimbabwe"
+            ]
+          }
+        },
+        "development_sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture",
+              "climate-change",
+              "disabilities",
+              "education",
+              "empowerment-and-accountability",
+              "environment",
+              "girls-and-women",
+              "health",
+              "humanitarian-emergencies-disasters",
+              "livelihoods",
+              "peace-and-access-to-justice",
+              "private-sector-business",
+              "technology",
+              "trade",
+              "water-and-sanitation"
+            ]
+          }
+        },
+        "eligible_entities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "non-governmental-organisations",
+              "uk-based-non-profit-organisations",
+              "uk-based-small-and-diaspora-organisations",
+              "companies",
+              "local-government",
+              "educational-institutions",
+              "individuals",
+              "humanitarian-relief-organisations"
+            ]
+          }
+        },
+        "value_of_funding": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "up-to-100000",
+              "100001-500000",
+              "500001-to-1000000",
+              "more-than-1000000"
+            ]
+          }
+        }
+      }
+    },
+    "maib_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "maib_report"
+          ]
+        },
+        "vessel_type": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "merchant-vessel-100-gross-tons-or-over",
+              "merchant-vessel-under-100-gross-tons",
+              "fishing-vessel",
+              "recreational-craft-sail",
+              "recreational-craft-power"
+            ]
+          }
+        },
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "investigation-report",
+            "safety-bulletin",
+            "completed-preliminary-examination",
+            "overseas-report",
+            "discontinued-investigation"
+          ]
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "medical_safety_alert_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "medical_safety_alert"
+          ]
+        },
+        "alert_type": {
+          "type": "string",
+          "enum": [
+            "drugs",
+            "devices",
+            "field-safety-notices",
+            "company-led-drugs"
+          ]
+        },
+        "medical_specialism": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "anaesthetics",
+              "cardiology",
+              "care-home-staff",
+              "cosmetic-surgery",
+              "critical-care",
+              "dentistry",
+              "general-practice",
+              "general-surgery",
+              "haematology-oncology",
+              "infection-prevention",
+              "obstetrics-gynaecology",
+              "ophthalmology",
+              "orthopaedics",
+              "paediatrics",
+              "pathology",
+              "pharmacy",
+              "physiotherapy-occupational-therapy",
+              "radiology",
+              "renal-medicine",
+              "theatre-practitioners",
+              "urology",
+              "vascular-cardiac-surgery"
+            ]
+          }
+        },
+        "issued_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "raib_report_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "raib_report"
+          ]
+        },
+        "railway_type": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "heavy-rail",
+              "light-rail",
+              "metros",
+              "heritage-railways"
+            ]
+          }
+        },
+        "report_type": {
+          "type": "string",
+          "enum": [
+            "investigation-report",
+            "bulletin",
+            "interim-report",
+            "discontinuation-report"
+          ]
+        },
+        "date_of_occurrence": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    },
+    "tax_tribunal_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "tax_tribunal_decision"
+          ]
+        },
+        "tribunal_decision_category": {
+          "type": "string",
+          "enum": [
+            "banking",
+            "charity",
+            "financial-services",
+            "land-registration",
+            "pensions",
+            "tax"
+          ]
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "utaac_decision_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "utaac_decision"
+          ]
+        },
+        "tribunal_decision_judges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_sub_categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tribunal_decision_decision_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "hidden_indexable_content": {
+          "type": "string"
+        }
+      }
+    },
+    "vehicle_recalls_and_faults_alert_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "vehicle_recalls_and_faults_alert"
+          ]
+        },
+        "fault_type": {
+          "type": "string",
+          "enum": [
+            "recall",
+            "non_urgent_fault"
+          ]
+        },
+        "faulty_item_type": {
+          "type": "string",
+          "enum": [
+            "vehicle",
+            "baby-seat",
+            "tyres",
+            "parts",
+            "agricultural-equipment",
+            "other-accessories"
+          ]
+        },
+        "manufacturer": {
+          "type": "string",
+          "enum": [
+            "alfa-romeo",
+            "audi",
+            "balco",
+            "bmw",
+            "bridgestone",
+            "britax",
+            "citroen",
+            "ferrari",
+            "mccormick-tractors-ltd",
+            "michelin",
+            "mitas-tyres-ltd",
+            "mothercare",
+            "nim-engineering-ltd",
+            "other-manufacturer"
+          ]
+        },
+        "faulty_item_model": {
+          "type": "string"
+        },
+        "serial_number": {
+          "type": "string"
+        },
+        "alert_issue_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_start_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
+        "build_end_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        }
+      }
+    }
+  }
+}

--- a/spec/fixtures/schemas/specialist_publisher/dfid_research_outputs_src.json
+++ b/spec/fixtures/schemas/specialist_publisher/dfid_research_outputs_src.json
@@ -48,7 +48,7 @@
       "filterable": false
     },
     {
-      "key": "theme",
+      "key": "dfid_theme",
       "name": "Theme",
       "type": "text",
       "preposition": "in themes",

--- a/spec/lib/dfid-transition/patch/govuk_content_schemas/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/govuk_content_schemas/themes_spec.rb
@@ -50,7 +50,7 @@ describe DfidTransition::Patch::GovukContentSchemas::Themes do
     let(:schema) { JSON.parse(File.read(patch_location)) }
 
     subject(:dfid_themes) do
-      schema.dig(*%w(definitions dfid_research_output_metadata properties theme))
+      schema.dig(*%w(definitions dfid_research_output_metadata properties dfid_theme))
     end
 
     it 'is a multi-valued type' do

--- a/spec/lib/dfid-transition/patch/govuk_content_schemas/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/govuk_content_schemas/themes_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'dfid-transition/patch/govuk_content_schemas/themes'
+require 'rdf/rdfxml'
+
+describe DfidTransition::Patch::GovukContentSchemas::Themes do
+  let(:patch_location) { nil }
+  subject(:patch) { DfidTransition::Patch::GovukContentSchemas::Themes.new(patch_location) }
+
+  it_behaves_like "holds onto the location of a schema file and warns us if it is not there"
+
+  describe '#location' do
+    context 'a location is not supplied' do
+      let(:patch_location) { nil }
+
+      it 'defaults to govuk_content_schemas/formats/specialist_document/details.json relative to the current directory' do
+        expect(patch.location).to eql(
+          File.expand_path(
+            '../govuk_content_schemas/formats/specialist_document/publisher/details.json',
+            Dir.pwd
+          )
+        )
+      end
+    end
+  end
+
+  describe '#run' do
+    let(:patch_location) { 'spec/fixtures/schemas/govuk_content_schemas/details.json' }
+    let(:r4d_skos_theme_repo) do
+      RDF::Repository.load('spec/fixtures/service-results/r4d_skos_themes.rdf')
+    end
+
+    before do
+      allow(patch).to receive(:themes_query).and_return(
+        DfidTransition::Extract::Query::Themes.new(
+          SPARQL::Client.new(r4d_skos_theme_repo)
+        )
+      )
+
+      FileUtils.cp(
+        'spec/fixtures/schemas/govuk_content_schemas/details_src.json',
+        patch_location)
+
+      patch.run
+    end
+
+    after do
+      File.delete(patch_location)
+    end
+
+    let(:schema) { JSON.parse(File.read(patch_location)) }
+
+    subject(:dfid_themes) do
+      schema.dig(*%w(definitions dfid_research_output_metadata properties theme))
+    end
+
+    it 'is a multi-valued type' do
+      expect(dfid_themes['type']).to eql('array')
+    end
+
+    it 'adds only top-level theme data to the schema' do
+      expect(dfid_themes['enum'].count).to eq(12)
+    end
+
+    it 'underscores/downcases values' do
+      expect(dfid_themes['enum']).to include('climate_and_environment')
+    end
+  end
+end

--- a/spec/lib/dfid-transition/patch/rummager/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/rummager/themes_spec.rb
@@ -1,15 +1,18 @@
 require 'spec_helper'
 require 'json'
+require 'rdf/rdfxml'
 require 'dfid-transition/patch/rummager/themes'
 
 describe DfidTransition::Patch::Rummager::Themes do
   it_behaves_like "holds onto the location of a schema file and warns us if it is not there"
 
+  subject(:patcher) { DfidTransition::Patch::Rummager::Themes.new(patch_location) }
+
   describe '#location' do
     context 'a location is not supplied' do
-      it 'defaults to config/schemas/document_types/dfid_research_outputs.json relative to the current directory' do
-        patcher = DfidTransition::Patch::Rummager::Themes.new(nil)
+      let(:patch_location) { nil }
 
+      it 'defaults to config/schemas/document_types/dfid_research_outputs.json relative to the current directory' do
         expect(patcher.location).to eq(
           File.expand_path(
             File.join(
@@ -20,24 +23,40 @@ describe DfidTransition::Patch::Rummager::Themes do
 
   describe '#run' do
     context 'the target schema file exists' do
-      let(:schema_src) { 'spec/fixtures/schemas/rummager/dfid_research_outputs_no_fields.json' }
+      let(:schema_src)     { 'spec/fixtures/schemas/rummager/dfid_research_outputs_no_fields.json' }
       let(:patch_location) { 'spec/fixtures/schemas/rummager/dfid_research_outputs.json' }
+      let(:r4d_skos_theme_repo) do
+        RDF::Repository.load('spec/fixtures/service-results/r4d_skos_themes.rdf')
+      end
 
       before do
+        allow(patcher).to receive(:themes_query).and_return(
+          DfidTransition::Extract::Query::Themes.new(
+            SPARQL::Client.new(r4d_skos_theme_repo)
+          )
+        )
+
         FileUtils.cp(schema_src, patch_location)
+
+        patcher.run
       end
 
       after do
         File.delete(patch_location)
       end
 
-      it 'patches the schema with all of the country labels and values' do
-        patcher = DfidTransition::Patch::Rummager::Themes.new(patch_location)
+      subject(:parsed_json) { JSON.parse(File.read(patch_location)) }
 
-        patcher.run
-
-        parsed_json = JSON.parse(File.read(patch_location))
+      it 'adds the theme field' do
         expect(parsed_json['fields']).to include('theme')
+      end
+
+      it 'patches the schema with all of the theme labels and values' do
+        theme_expansions = parsed_json.dig('expanded_search_result_fields', 'theme')
+        expect(theme_expansions).to include(
+          'value' => 'climate_and_environment',
+          'label' => 'Climate and Environment'
+        )
       end
     end
   end

--- a/spec/lib/dfid-transition/patch/rummager/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/rummager/themes_spec.rb
@@ -48,11 +48,11 @@ describe DfidTransition::Patch::Rummager::Themes do
       subject(:parsed_json) { JSON.parse(File.read(patch_location)) }
 
       it 'adds the theme field' do
-        expect(parsed_json['fields']).to include('theme')
+        expect(parsed_json['fields']).to include('dfid_theme')
       end
 
       it 'patches the schema with all of the theme labels and values' do
-        theme_expansions = parsed_json.dig('expanded_search_result_fields', 'theme')
+        theme_expansions = parsed_json.dig('expanded_search_result_fields', 'dfid_theme')
         expect(theme_expansions).to include(
           'value' => 'climate_and_environment',
           'label' => 'Climate and Environment'

--- a/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
@@ -28,15 +28,15 @@ describe DfidTransition::Patch::SpecialistPublisher::Themes do
     let(:schema) { JSON.parse(File.read(patch_location)) }
     let(:themes) { schema['facets'].find { |facet| facet['key'] == 'theme' } }
 
-    it 'adds theme data to the schema' do
+    it 'adds only top-level theme data to the schema' do
       patch.run
 
       allowed_values = themes['allowed_values']
 
-      expect(allowed_values.count).to eq(95)
+      expect(allowed_values.count).to eq(12)
       expect(allowed_values).to include(
-        'label' => 'Neglected Tropical Diseases',
-        'value' => 'Neglected%20Tropical%20Diseases'
+        'label' => 'Climate and Environment',
+        'value' => 'Climate%20and%20Environment'
       )
     end
 

--- a/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
@@ -33,7 +33,7 @@ describe DfidTransition::Patch::SpecialistPublisher::Themes do
     end
 
     let(:schema) { JSON.parse(File.read(patch_location)) }
-    let(:themes) { schema['facets'].find { |facet| facet['key'] == 'theme' } }
+    let(:themes) { schema['facets'].find { |facet| facet['key'] == 'dfid_theme' } }
 
     subject(:allowed_values) { themes['allowed_values'] }
 

--- a/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'dfid-transition/patch/specialist_publisher/themes'
+require 'rdf/rdfxml'
 
 describe DfidTransition::Patch::SpecialistPublisher::Themes do
   let(:patch_location) { nil }

--- a/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
@@ -14,11 +14,17 @@ describe DfidTransition::Patch::SpecialistPublisher::Themes do
     end
 
     before do
-      expect(RDF::Repository).to receive(:load).and_return(r4d_skos_theme_repo)
+      allow(patch).to receive(:themes_query).and_return(
+        DfidTransition::Extract::Query::Themes.new(
+          SPARQL::Client.new(r4d_skos_theme_repo)
+        )
+      )
 
       FileUtils.cp(
         'spec/fixtures/schemas/specialist_publisher/dfid_research_outputs_src.json',
         patch_location)
+
+      patch.run
     end
 
     after do
@@ -28,21 +34,20 @@ describe DfidTransition::Patch::SpecialistPublisher::Themes do
     let(:schema) { JSON.parse(File.read(patch_location)) }
     let(:themes) { schema['facets'].find { |facet| facet['key'] == 'theme' } }
 
+    subject(:allowed_values) { themes['allowed_values'] }
+
     it 'adds only top-level theme data to the schema' do
-      patch.run
-
-      allowed_values = themes['allowed_values']
-
       expect(allowed_values.count).to eq(12)
+    end
+
+    it 'leaves labels alone and underscores/downcases values' do
       expect(allowed_values).to include(
         'label' => 'Climate and Environment',
-        'value' => 'Climate%20and%20Environment'
+        'value' => 'climate_and_environment'
       )
     end
 
     it 'sorts themes alphabetically by label' do
-      patch.run
-
       labels = themes['allowed_values'].map { |lv| lv['label'] }
       expect(labels).to eql(labels.sort), 'theme labels are not sorted'
     end


### PR DESCRIPTION
User research suggests we don't need finer-grained themes yet. 
- Change the field name to `dfid_theme`
- Add a patcher for `govuk_content_schemas`
- Separate concerns so that all three patchers can use the same query
