### PR TITLE
Add a filterable "first_published_at" field

### DIFF
--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -54,9 +54,12 @@ module DfidTransition
       def metadata
         {
           document_type: "dfid_research_output",
-          country: countries,
           bulk_published: true
-        }
+        }.merge(format_specific_metadata)
+      end
+
+      def first_published_at
+        solution[:date].to_s
       end
 
       def public_updated_at
@@ -68,7 +71,7 @@ module DfidTransition
       end
 
       def format_specific_metadata
-        { country: countries }
+        { country: countries, first_published_at: first_published_at }
       end
 
       def organisations

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -77,12 +77,21 @@ module DfidTransition::Transform
         expect(doc.public_updated_at).to eql('2016-04-28T09:52:00')
       end
 
+      it 'has a first_published_at date' do
+        expect(doc.first_published_at).to eql('2016-04-28T09:52:00')
+      end
+
       it 'splits country codes' do
         expect(doc.countries).to eql(%w(AZ GB))
       end
 
-      it 'has these countries in format_specific_metadata' do
-        expect(doc.format_specific_metadata).to eql(country: doc.countries)
+      describe '#format_specific_metadata' do
+        it 'has our countries' do
+          expect(doc.format_specific_metadata[:country]).to eql(doc.countries)
+        end
+        it 'has our first_published_at date' do
+          expect(doc.format_specific_metadata[:first_published_at]).to eql(doc.first_published_at)
+        end
       end
 
       it 'has fixed organisations' do
@@ -124,6 +133,9 @@ module DfidTransition::Transform
         end
         it 'says that this is bulk_published' do
           expect(metadata[:bulk_published]).to be true
+        end
+        it 'has the published date of the research output' do
+          expect(metadata[:first_published_at]).to eql(doc.first_published_at)
         end
       end
 


### PR DESCRIPTION
This needs to be separate and distinct from the publishing platform's
 "Published" date field, which is updated in lockstep with major updates
and will not appear when items are `bulk_published`. There is already
 a "first_published_at" field in rummager, so we just use this.

This gives editors the opportunity to enter the real published date
of a research output.
## Related PRs

https://github.com/alphagov/specialist-publisher-rebuild/pull/767
https://github.com/alphagov/rummager/pull/638
