### PR TITLE
Send organisations to correct links endpoint.

### DIFF
--- a/lib/dfid-transition/load/outputs.rb
+++ b/lib/dfid-transition/load/outputs.rb
@@ -28,6 +28,7 @@ module DfidTransition
           should_discard_draft = true
           begin
             publishing_api.put_content(doc.content_id, doc.to_json)
+            publishing_api.patch_links(doc.content_id, doc.links)
             publishing_api.publish(doc.content_id, update_type)
             logger.info "Published #{doc.title} at "\
               "http://www.dev.gov.uk/dfid-research-outputs/#{doc.original_id}"

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -147,7 +147,14 @@ module DfidTransition
                              ],
           redirects:         [],
           update_type:       'minor',
-          organisations:     organisations
+        }
+      end
+
+      def links
+        {
+          links: {
+            organisations:     organisations
+          }
         }
       end
     end

--- a/spec/lib/dfid-transition/extract/query/base_spec.rb
+++ b/spec/lib/dfid-transition/extract/query/base_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'dfid-transition/extract/query/Base'
+require 'dfid-transition/extract/query/base'
 
 describe DfidTransition::Extract::Query::Base do
   class TestQuery < DfidTransition::Extract::Query::Base

--- a/spec/lib/dfid-transition/load/outputs_spec.rb
+++ b/spec/lib/dfid-transition/load/outputs_spec.rb
@@ -49,6 +49,15 @@ describe DfidTransition::Load::Outputs do
         expect(publishing_api).to have_received(:publish).with(uuid, 'major')
       end
 
+      it 'sends the organisation in a call to links' do
+        expect(publishing_api).to have_received(:patch_links).with(
+          uuid,
+          links: {
+            organisations: [instance_of(String)]
+          },
+        )
+      end
+
       it 'adds the document to rummager' do
         expect(rummager).to have_received(:add_document).with(
           'dfid_research_output',
@@ -73,6 +82,7 @@ describe DfidTransition::Load::Outputs do
 
       before do
         allow(publishing_api).to receive(:put_content)
+        allow(publishing_api).to receive(:patch_links)
         allow(publishing_api).to receive(:publish).and_raise(
           GdsApi::HTTPUnprocessableEntity.new(422, 'Something went bang when we tried to publish'))
         allow(publishing_api).to receive(:discard_draft)


### PR DESCRIPTION
`organisations` is not a supported key for the main content endpoint;
it needs to be supplied in a separate call to `patch_links`.
