### PR TITLE
Fix typo in DFID ORGANISATION_CONTENT_ID

### DIFF
--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/string/strip'
 module DfidTransition
   LINKED_DEVELOPMENT_OUTPUT_URI =
     %r{http://linked-development.org/r4d/output/(?<id>[0-9]+?)/}
-  ORGANISATION_CONTENT_ID       = "b994552-7644-404d-a770-a2fe659c661f".freeze
+  ORGANISATION_CONTENT_ID       = "db994552-7644-404d-a770-a2fe659c661f".freeze
 
   module Transform
     class Document

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -95,7 +95,7 @@ module DfidTransition::Transform
       end
 
       it 'has fixed organisations' do
-        dfid_content_id = 'b994552-7644-404d-a770-a2fe659c661f'
+        dfid_content_id = 'db994552-7644-404d-a770-a2fe659c661f'
         expect(doc.organisations).to eql([dfid_content_id])
       end
 


### PR DESCRIPTION
- Missing leading 'd' – not a valid UUID
- Brought to light by
  https://github.com/alphagov/dfid-transition/pull/27
