### PR TITLE
Remove fudged GROUP_CONCAT

### DIFF
--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -10,20 +10,19 @@ module DfidTransition
           PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
           PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
 
-          SELECT DISTINCT ?output ?date ?abstract
+          SELECT DISTINCT ?output ?date ?abstract ?title
                           (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
-                          (GROUP_CONCAT(DISTINCT(?titleSource)) AS ?title)
                           (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
           WHERE {
             ?output a ont:Article ;
-                    dcterms:title ?titleSource ;
+                    dcterms:title ?title ;
                     dcterms:abstract ?abstract ;
                     dcterms:date ?date .
 
             OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
             OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
 
-          } GROUP BY ?output ?date ?abstract
+          } GROUP BY ?output ?date ?abstract ?title
           ORDER BY DESC(?date)
           LIMIT 20
         SPARQL


### PR DESCRIPTION
CABI used to have multiple titles for some outputs, and there was no
indication of primacy. We had to munge our titles together with a
GROUP_CONCAT. These titles have now been teased apart and we can
guarantee that each output has only one title.

Remove the GROUP_CONCAT from the query as a result.
