### PR TITLE
Remove the summary

### DIFF
--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -43,8 +43,7 @@ module DfidTransition
       end
 
       def summary
-        "This is an example summary for output #{original_id}. The citation would ordinarily
-         appear here but we need CABI to include that data in their triples."
+        ''
       end
 
       def base_path

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -61,8 +61,8 @@ module DfidTransition::Transform
           '‘And Then He Switched off the Phone’: Mobile Phones ...')
       end
 
-      it 'fixes #summary to the example' do
-        expect(doc.summary).to include('This is an example summary for output 5050')
+      it 'always has an empty summary' do
+        expect(doc.summary).to be_empty
       end
 
       it 'knows the original ID for things' do


### PR DESCRIPTION
It was just fixed text and referenced our then intention to use the
citation as the summary. Now we have the citation, it's going
elsewhere, so remove the summary (even if it doesn't do much for the
look of the page)
