### PR TITLE
Hide blank abstracts

### DIFF
--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -107,9 +107,13 @@ module DfidTransition
 
       def body
         "## Authors\n\n"\
-        "#{creators.map { |name| "* #{name}" }.join("\n")}\n\n"\
-        "## Abstract\n"\
-        "#{abstract}\n"
+        "#{creators.map { |name| "* #{name}" }.join("\n")}\n\n" +
+          if blank_abstract?
+            ''
+          else
+            "## Abstract\n"\
+            "#{abstract}\n"
+          end
       end
 
       def headers
@@ -155,6 +159,12 @@ module DfidTransition
             organisations:     organisations
           }
         }
+      end
+
+    private
+
+      def blank_abstract?
+        ['-', ''].include?(abstract.strip)
       end
     end
   end

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -170,6 +170,29 @@ module DfidTransition::Transform
         it 'corrects non-standard HTML – the list is separate' do
           expect(body).to include("\n* Hello")
         end
+
+        context 'the abstract is blank' do
+          context 'with a single dash' do
+            before { solution_hash[:abstract] = literal('-') }
+            it 'has no abstract section' do
+              expect(body).not_to include('## Abstract')
+            end
+          end
+
+          context 'with a single dash and leading/trailing space' do
+            before { solution_hash[:abstract] = literal(' - ') }
+            it 'has no abstract section' do
+              expect(body).not_to include('## Abstract')
+            end
+          end
+
+          context 'properly blank' do
+            before { solution_hash[:abstract] = literal('') }
+            it 'has no abstract section' do
+              expect(body).not_to include('## Abstract')
+            end
+          end
+        end
       end
 
       describe '#creators' do


### PR DESCRIPTION
- Typically '-' in the results
- Would translate to list with one blank item otherwise
