### PR TITLE
Move authors to metadata

### DIFF
--- a/lib/dfid-transition/transform/body.erb.md
+++ b/lib/dfid-transition/transform/body.erb.md
@@ -4,12 +4,6 @@
 <%= abstract %>
 <% end %>
 
-## Authors
-
-<% creators.each do |creator| %>
-* <%= creator %>
-<% end %>
-
 ## Citation
 
 <%= citation %>

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -71,7 +71,11 @@ module DfidTransition
       end
 
       def format_specific_metadata
-        { country: countries, first_published_at: first_published_at }
+        {
+          country: countries,
+          first_published_at: first_published_at,
+          dfid_authors: creators
+        }
       end
 
       def organisations

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -90,6 +90,9 @@ module DfidTransition::Transform
         it 'has our countries' do
           expect(doc.format_specific_metadata[:country]).to eql(doc.countries)
         end
+        it 'has our authors' do
+          expect(doc.format_specific_metadata[:dfid_authors]).to eql(doc.creators)
+        end
         it 'has our first_published_at date' do
           expect(doc.format_specific_metadata[:first_published_at]).to eql(doc.first_published_at)
         end
@@ -159,13 +162,6 @@ module DfidTransition::Transform
         end
         it 'has the citation' do
           expect(body).to include(doc.citation)
-        end
-        it 'has a header with no indents for the creators' do
-          expect(body).to match(/^## Authors/)
-        end
-        it 'has a list for the creators' do
-          expect(body).to include('* Heinlein, R.')
-          expect(body).to include('* Asimov, A.')
         end
         it 'has the abstract as markdown' do
           expect(body).to include('This research design and methods paper')


### PR DESCRIPTION
- Since adding citation, Authors now appear in the body twice
- Citation is too long-form to go in metadata
- Move authors out instead
## Related PRs
- https://github.com/alphagov/specialist-publisher-rebuild/pull/809
- https://github.com/alphagov/rummager/pull/662
