### PR TITLE
Attachments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'nokogiri'
 gem 'gds-api-adapters'
 gem 'govspeak'
 gem 'activesupport'
+gem 'concurrent-ruby'
 gem 'kramdown'
 gem 'erubis'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'activesupport'
 gem 'concurrent-ruby'
 gem 'kramdown'
 gem 'erubis'
+gem 'mime-types'
 
 group :development, :test do
   gem 'govuk-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ DEPENDENCIES
   govspeak
   govuk-lint
   kramdown
+  mime-types
   nokogiri
   pry
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  concurrent-ruby
   erubis
   gds-api-adapters
   govspeak

--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -13,12 +13,14 @@ module DfidTransition
           SELECT DISTINCT ?output ?date ?abstract ?title ?citation
                           (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
                           (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
+                          (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
           WHERE {
             ?output a ont:Article ;
                     dcterms:title ?title ;
                     dcterms:abstract ?abstract ;
                     dcterms:bibliographicCitation ?citation ;
-                    dcterms:date ?date .
+                    dcterms:date ?date ;
+                    ont:uri ?uri .
 
             OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
             OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }

--- a/lib/dfid-transition/load/outputs.rb
+++ b/lib/dfid-transition/load/outputs.rb
@@ -47,7 +47,6 @@ module DfidTransition
           logger.warn "#{doc.original_url}: #{e}"
         rescue => e
           logger.error(e)
-          raise
         ensure
           # Don't leave us in a state where we could 422
           publishing_api.discard_draft(doc.content_id) if should_discard_draft

--- a/lib/dfid-transition/load/outputs.rb
+++ b/lib/dfid-transition/load/outputs.rb
@@ -75,7 +75,7 @@ module DfidTransition
         end
       end
 
-      private
+    private
 
       def content_id_from(base_path)
         publishing_api.lookup_content_id(base_path: base_path)

--- a/lib/dfid-transition/load/outputs.rb
+++ b/lib/dfid-transition/load/outputs.rb
@@ -17,14 +17,16 @@ module DfidTransition
         @logger = logger
       end
 
-      def transform_documents
-        @transform_documents =
-          solutions.map { |solution| DfidTransition::Transform::Document.new(solution) }
+      def run
+        documents.each(&:async_download_attachments)
+        documents.each { |doc| publish(doc) }
       end
 
-      def run
-        transform_documents.each(&:async_download_attachments)
-        transform_documents.each { |doc| publish(doc) }
+    private
+
+      def documents
+        @documents =
+          solutions.map { |solution| DfidTransition::Transform::Document.new(solution) }
       end
 
       def publish(doc)
@@ -74,8 +76,6 @@ module DfidTransition
           end
         end
       end
-
-    private
 
       def content_id_from(base_path)
         publishing_api.lookup_content_id(base_path: base_path)

--- a/lib/dfid-transition/load/outputs.rb
+++ b/lib/dfid-transition/load/outputs.rb
@@ -6,49 +6,77 @@ module DfidTransition
   module Load
     class Outputs
       attr_reader :logger
-      attr_accessor :publishing_api, :rummager, :solutions
+      attr_accessor :publishing_api, :rummager, :asset_manager, :solutions
 
-      def initialize(publishing_api, rummager, solutions, logger: Logger.new(STDERR))
+      def initialize(publishing_api, rummager, asset_manager, solutions, logger: Logger.new(STDERR))
         self.publishing_api = publishing_api
         self.rummager       = rummager
+        self.asset_manager  = asset_manager
         self.solutions      = solutions
 
         @logger = logger
       end
 
+      def transform_documents
+        @transform_documents =
+          solutions.map { |solution| DfidTransition::Transform::Document.new(solution) }
+      end
+
       def run
-        solutions.each do |solution|
-          doc = DfidTransition::Transform::Document.new(solution)
+        transform_documents.each(&:async_download_attachments)
+        transform_documents.each { |doc| publish(doc) }
+      end
 
-          existing_draft_content_id = content_id_from(doc.base_path)
-          doc.content_id = existing_draft_content_id if existing_draft_content_id
+      def publish(doc)
+        existing_draft_content_id = content_id_from(doc.base_path)
+        doc.content_id            = existing_draft_content_id if existing_draft_content_id
 
-          update_type = existing_draft_content_id ? 'republish' : 'major'
+        update_type = existing_draft_content_id ? 'republish' : 'major'
 
-          should_discard_draft = true
-          begin
-            publishing_api.put_content(doc.content_id, doc.to_json)
-            publishing_api.patch_links(doc.content_id, doc.links)
-            publishing_api.publish(doc.content_id, update_type)
-            logger.info "Published #{doc.title} at "\
+        wait_for_upload_to_asset_manager(doc.attachments)
+
+        should_discard_draft = true
+        begin
+          publishing_api.put_content(doc.content_id, doc.to_json)
+          publishing_api.patch_links(doc.content_id, doc.links)
+          publishing_api.publish(doc.content_id, update_type)
+          logger.info "Published #{doc.title} at "\
               "http://www.dev.gov.uk/dfid-research-outputs/#{doc.original_id}"
-            should_discard_draft = false
-          rescue GdsApi::HTTPUnprocessableEntity => e
-            logger.warn "#{doc.original_url}: #{e}"
-          ensure
-            # Don't leave us in a state where we could 422
-            publishing_api.discard_draft(doc.content_id) if should_discard_draft
-          end
+          should_discard_draft = false
+        rescue GdsApi::HTTPUnprocessableEntity => e
+          logger.warn "#{doc.original_url}: #{e}"
+        rescue => e
+          logger.error(e)
+          raise
+        ensure
+          # Don't leave us in a state where we could 422
+          publishing_api.discard_draft(doc.content_id) if should_discard_draft
+        end
 
-          rummager.add_document(
-            'dfid_research_output',
-            doc.base_path,
-            Govuk::Presenters::Search.new(doc).to_json,
-          )
+        rummager.add_document(
+          'dfid_research_output',
+          doc.base_path,
+          Govuk::Presenters::Search.new(doc).to_json,
+        )
+      end
+
+      def wait_for_upload_to_asset_manager(attachments)
+        attachments.select(&:hosted_at_r4d?).each do |attachment|
+          file = attachment.file # block on the value
+          case attachment.file_future.state
+          when :rejected
+            logger.warn(attachment.file_future.reason)
+          when :fulfilled
+            begin
+              attachment.save_to(asset_manager)
+            ensure
+              file.close
+            end
+          end
         end
       end
 
-    private
+      private
 
       def content_id_from(base_path)
         publishing_api.lookup_content_id(base_path: base_path)

--- a/lib/dfid-transition/load/outputs.rb
+++ b/lib/dfid-transition/load/outputs.rb
@@ -33,7 +33,7 @@ module DfidTransition
 
         update_type = existing_draft_content_id ? 'republish' : 'major'
 
-        wait_for_upload_to_asset_manager(doc.attachments)
+        wait_for_upload_to_asset_manager(doc.downloads)
 
         should_discard_draft = true
         begin
@@ -60,7 +60,7 @@ module DfidTransition
       end
 
       def wait_for_upload_to_asset_manager(attachments)
-        attachments.select(&:hosted_at_r4d?).each do |attachment|
+        attachments.each do |attachment|
           file = attachment.file # block on the value
           case attachment.file_future.state
           when :rejected

--- a/lib/dfid-transition/services.rb
+++ b/lib/dfid-transition/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/asset_manager'
 require 'gds_api/rummager'
 
 module DfidTransition
@@ -7,6 +8,13 @@ module DfidTransition
       @publishing_api ||= GdsApi::PublishingApiV2.new(
         Plek.new.find('publishing-api'),
         bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+      )
+    end
+
+    def self.asset_manager
+      @asset_manager ||= GdsApi::AssetManager.new(
+        Plek.new.find('asset-manager'),
+        bearer_token: ENV['ASSET_MANAGER_BEARER_TOKEN'] || 'example',
       )
     end
 

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -71,7 +71,7 @@ module DfidTransition
       end
 
       def to_json
-        return {} if external_link?
+        raise RuntimeError, '#to_json is not valid for an external link' if external_link?
 
         {
           url: asset_response.file_url,

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -65,11 +65,6 @@ module DfidTransition
         @asset_response = asset_manager.create_asset(file: file)
       end
 
-      def asset_response
-        @asset_response ||
-          (raise RuntimeError.new('#save_to(asset_manager) has not been called yet'))
-      end
-
       def to_json
         raise RuntimeError, '#to_json is not valid for an external link' if external_link?
 
@@ -81,6 +76,12 @@ module DfidTransition
           created_at: Time.now.to_datetime.rfc3339,
           content_id: content_id
         }
+      end
+
+    private
+      def asset_response
+        @asset_response ||
+          (raise RuntimeError.new('#save_to(asset_manager) has not been called yet'))
       end
     end
   end

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -19,19 +19,19 @@ module DfidTransition
 
       def file_future
         @file_future ||= case
-        when external_link?
-          Concurrent::Future.new { false }
-        when hosted_at_r4d?
-          Concurrent::Future.new do
-            download_to = "/tmp/#{filename}"
-            File.open(download_to, 'w+') do |file|
-              RestClient.get original_url.to_s do |str|
-                file.write(str)
-              end
-            end
-            File.open(download_to, 'r')
-          end
-        end.tap { |future| future.execute }
+                         when external_link?
+                           Concurrent::Future.new { false }
+                         when hosted_at_r4d?
+                           Concurrent::Future.new do
+                             download_to = "/tmp/#{filename}"
+                             File.open(download_to, 'w+') do |file|
+                               RestClient.get original_url.to_s do |str|
+                                 file.write(str)
+                               end
+                             end
+                             File.open(download_to, 'r')
+                           end
+                         end.tap(&:execute)
       end
 
       def file

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -20,7 +20,7 @@ module DfidTransition
       def file_future
         @file_future ||= case
                          when external_link?
-                           Concurrent::Future.new { false }
+                           raise RuntimeError, 'external links cannot be downloaded'
                          when hosted_at_r4d?
                            Concurrent::Future.new do
                              download_to = "/tmp/#{filename}"
@@ -30,8 +30,8 @@ module DfidTransition
                                end
                              end
                              File.open(download_to, 'r')
-                           end
-                         end.tap(&:execute)
+                           end.tap(&:execute)
+                         end
       end
 
       def file

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -31,8 +31,8 @@ module DfidTransition
                                end
                              end
                              File.open(download_to, 'r')
-                           end.tap(&:execute)
-                         end
+                           end
+                         end.tap(&:execute)
       end
 
       def file

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -1,0 +1,81 @@
+require 'uri'
+require 'concurrent/future'
+require 'securerandom'
+
+module DfidTransition
+  module Transform
+    class Attachment
+      attr_reader :original_url
+
+      def initialize(original_url)
+        @original_url = URI(original_url)
+        raise ArgumentError, "expected a URL, got #{original_url}" unless @original_url.is_a?(URI::HTTP)
+      end
+
+      def content_id
+        @content_id = SecureRandom.uuid
+      end
+
+      def file_future
+        @file_future ||= if external_link?
+          Concurrent::Future.new { false }
+        else
+          Concurrent::Future.new do
+            download_to = "/tmp/#{filename}"
+            puts download_to
+            File.open(download_to, 'w+') do |file|
+              RestClient.get original_url.to_s do |str|
+                file.write(str)
+              end
+            end
+            File.open(download_to, 'r')
+          end
+        end.tap { |future| future.execute }
+      end
+
+      def file
+        file_future.value
+      end
+
+      def external_link?
+        !hosted_at_r4d?
+      end
+
+      def hosted_at_r4d?
+        original_url.host == 'r4d.dfid.gov.uk'
+      end
+
+      def filename
+        File.basename(original_url.path).sub('/', '')
+      end
+
+      def snippet
+        case
+        when hosted_at_r4d? then "[InlineAttachment:#{filename}]"
+        when external_link? then original_url
+        end
+      end
+
+      def link_to_asset
+        "[#{filename}](#{@asset_response.file_url})"
+      end
+
+      def save_to(asset_manager)
+        @asset_response = asset_manager.create_asset(file: file)
+      end
+
+      def to_json
+        return {} if external_link?
+
+        {
+          url: @asset_response.file_url,
+          title: filename,
+          content_type: 'application/pdf',
+          updated_at: Time.now.to_datetime.rfc3339,
+          created_at: Time.now.to_datetime.rfc3339,
+          content_id: content_id
+        }
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -2,6 +2,7 @@ require 'uri'
 require 'concurrent/future'
 require 'securerandom'
 require 'rest-client'
+require 'mime-types'
 
 module DfidTransition
   module Transform
@@ -69,16 +70,22 @@ module DfidTransition
         raise RuntimeError, '#to_json is not valid for an external link' if external_link?
 
         {
-          url: asset_response.file_url,
-          title: filename,
-          content_type: 'application/pdf',
-          updated_at: Time.now.to_datetime.rfc3339,
-          created_at: Time.now.to_datetime.rfc3339,
-          content_id: content_id
+          url:          asset_response.file_url,
+          title:        filename,
+          content_type: content_type,
+          updated_at:   Time.now.to_datetime.rfc3339,
+          created_at:   Time.now.to_datetime.rfc3339,
+          content_id:   content_id
         }
       end
 
     private
+
+      def content_type
+        mime = MIME::Types.type_for(filename).first
+        mime.content_type if mime
+      end
+
       def asset_response
         @asset_response ||
           (raise RuntimeError.new('#save_to(asset_manager) has not been called yet'))

--- a/lib/dfid-transition/transform/body.erb.md
+++ b/lib/dfid-transition/transform/body.erb.md
@@ -7,3 +7,9 @@
 ## Citation
 
 <%= citation %>
+
+## Links
+
+<% attachments.each do |attachment| %>
+<%= attachment.snippet %>
+<% end %>

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -104,15 +104,16 @@ module DfidTransition
           metadata: metadata,
           change_history: change_history
         }.tap do |details_hash|
-          details_hash[:headers] = headers
-          if attachments
-            details_hash[:attachments] = attachments.map(&:to_json)
-          end
+          details_hash[:headers]     = headers
+          details_hash[:attachments] = attachments.map(&:to_json) if attachments
         end
       end
 
       def attachments
-        @attachments ||= solution[:uris].to_s.split(' ').map {|uri| Attachment.new(uri)}
+        @attachments ||= begin
+          uris = solution[:uris].to_s.split(' ')
+          uris.map {|uri| Attachment.new(uri)}
+        end
       end
 
       def async_download_attachments

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -112,7 +112,7 @@ module DfidTransition
       def attachments
         @attachments ||= begin
           uris = solution[:uris].to_s.split(' ')
-          uris.map {|uri| Attachment.new(uri)}
+          uris.map { |uri| Attachment.new(uri) }
         end
       end
 

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -105,7 +105,7 @@ module DfidTransition
           change_history: change_history
         }.tap do |details_hash|
           details_hash[:headers]     = headers
-          details_hash[:attachments] = attachments.map(&:to_json) if attachments
+          details_hash[:attachments] = attachments.select(&:hosted_at_r4d?).map(&:to_json) if attachments
         end
       end
 

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -105,7 +105,7 @@ module DfidTransition
           change_history: change_history
         }.tap do |details_hash|
           details_hash[:headers]     = headers
-          details_hash[:attachments] = attachments.select(&:hosted_at_r4d?).map(&:to_json) if attachments
+          details_hash[:attachments] = downloads.map(&:to_json) if attachments
         end
       end
 
@@ -116,8 +116,12 @@ module DfidTransition
         end
       end
 
+      def downloads
+        attachments.select(&:hosted_at_r4d?)
+      end
+
       def async_download_attachments
-        attachments.each(&:file_future)
+        downloads.each(&:file_future)
       end
 
       def abstract

--- a/lib/govuk/presenters/govspeak.rb
+++ b/lib/govuk/presenters/govspeak.rb
@@ -2,16 +2,27 @@ require 'govspeak'
 
 module Govuk
   module Presenters
-    module Govspeak
-      class << self
-        def present(govspeak)
-          [
-            { content_type: "text/govspeak", content: govspeak },
-            {
-              content_type: "text/html",
-              content:      ::Govspeak::Document.new(govspeak).to_html
-            }
-          ]
+    class Govspeak
+      attr_accessor :govspeak, :attachments
+
+      def initialize(govspeak, attachments)
+        self.govspeak = govspeak
+        self.attachments = attachments
+      end
+
+      def present
+        [
+          { content_type: "text/govspeak", content: govspeak },
+          {
+            content_type: "text/html",
+            content:      ::Govspeak::Document.new(resolve_inline_attachments).to_html
+          }
+        ]
+      end
+
+      def resolve_inline_attachments
+        attachments.select(&:hosted_at_r4d?).inject(govspeak) do |body, attachment|
+          body.gsub(attachment.snippet, attachment.link_to_asset)
         end
       end
     end

--- a/lib/tasks/load/outputs.rake
+++ b/lib/tasks/load/outputs.rake
@@ -10,6 +10,7 @@ namespace :load do
       loader = Load::Outputs.new(
         Services.publishing_api,
         Services.rummager,
+        Services.asset_manager,
         output_solutions
       )
       loader.run

--- a/spec/lib/dfid-transition/load/outputs_spec.rb
+++ b/spec/lib/dfid-transition/load/outputs_spec.rb
@@ -5,7 +5,7 @@ require 'gds_api/exceptions'
 describe DfidTransition::Load::Outputs do
   let(:publishing_api) { spy('publishing-api') }
   let(:rummager)       { spy('rummager') }
-  let(:asset_manager)  { spy('asset_manager' )}
+  let(:asset_manager)  { spy('asset_manager') }
   let(:solutions)      { [] }
   let(:null_logger)    { double('Logger').as_null_object }
 

--- a/spec/lib/dfid-transition/load/outputs_spec.rb
+++ b/spec/lib/dfid-transition/load/outputs_spec.rb
@@ -41,8 +41,14 @@ describe DfidTransition::Load::Outputs do
     before do
       allow(solution).to receive(:[]) { |key| solution_hash[key] }
       allow(publishing_api).to receive(:lookup_content_id).and_return(existing_content_id)
-      stub_request(:get, onsite_pdf) { 'This is PDF content, honest' }
+      stub_request(:get, onsite_pdf).to_return(body: 'This is PDF content, honest')
       allow(asset_manager).to receive(:create_asset).with(file: instance_of(File)).and_return(asset_response)
+    end
+
+    after do
+      loader.send(:documents).each do |document|
+        document.downloads.each { |download| File.delete("/tmp/#{download.filename}") }
+      end
     end
 
     context 'there is one good solution and no pre-existing content' do

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -1,0 +1,52 @@
+ require 'spec_helper'
+require 'dfid-transition/transform/attachment'
+
+module DfidTransition::Transform
+  describe Attachment do
+    subject(:attachment) { Attachment.new(original_url) }
+
+    context 'nothing usable is given' do
+      it 'fails given completely the wrong type' do
+        expect { Attachment.new(1) }.to raise_error(ArgumentError, /expected URI object or URI string/)
+      end
+      it 'fails given a URI that isn\'t a URL' do
+        expect { Attachment.new('some:uri') }.to raise_error(ArgumentError, /expected a URL/)
+      end
+    end
+
+    describe '#hosted_at_r4d?' do
+      subject { attachment.hosted_at_r4d? }
+
+      context 'given a URL that is offsite' do
+        let(:original_url) { 'http://example.com/offsite' }
+        it { is_expected.to be false }
+      end
+
+      context 'given a URL that is onsite' do
+        let(:original_url) { 'http://r4d.dfid.gov.uk/some/file.pdf' }
+        it { is_expected.to be true }
+      end
+    end
+
+    describe '#filename' do
+      context 'a filename with an extension' do
+        let(:original_url) { 'http://example.com/some/path/title_of_the_file.pdf' }
+        it 'uses the filename' do
+          expect(attachment.filename).to eql('title_of_the_file.pdf')
+        end
+      end
+
+      context 'a path but no extension' do
+        let(:original_url) { 'http://example.com/some/path/' }
+        it 'uses the last part of the path' do
+          expect(attachment.filename).to eql('path')
+        end
+      end
+
+      context 'no path at all' do
+        let(:original_url) { 'http://example.com/' }
+        example { expect(attachment.filename).to be_empty }
+      end
+    end
+  end
+end

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -48,5 +48,59 @@ module DfidTransition::Transform
         example { expect(attachment.filename).to be_empty }
       end
     end
+
+    describe '#content_id' do
+      let(:original_url) { 'http://r4d.dfid.gov.uk/pdfs/some.pdf' }
+      let(:uuid) { /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/ }
+
+      it 'is a uuid' do
+        expect(attachment.content_id).to match uuid
+      end
+
+      it 'is only minted once' do
+        expect(attachment.content_id).to eql(attachment.content_id)
+      end
+    end
+
+    describe '#snippet' do
+      subject { attachment.snippet }
+
+      context 'it is hosted at r4d' do
+        let(:original_url) { 'http://r4d.dfid.gov.uk/some/file.pdf' }
+        it { is_expected.to eql('[InlineAttachment:file.pdf]') }
+      end
+      context 'it is hosted offsite' do
+        let(:original_url) { 'http://www.example.com/some/file.pdf' }
+        it { is_expected.to eql('[file.pdf](http://www.example.com/some/file.pdf)') }
+      end
+    end
+
+    describe '#file_future' do
+      subject { attachment.file_future }
+
+      context 'an offsite URL' do
+        let(:original_url) { 'http://example.com/1234' }
+        it { is_expected.to be_a(Concurrent::Future) }
+
+        it 'has a value of false' do
+          expect(attachment.file).to be false
+        end
+      end
+      context 'an onsite URL' do
+        let(:original_url) { 'http://r4d.dfid.gov.uk/pdfs/some.pdf' }
+        let(:pdf_content) { 'This is PDF content, honest' }
+
+        before do
+          stub_request(:get, original_url).to_return(body: pdf_content)
+        end
+
+        it { is_expected.to be_a(Concurrent::Future) }
+
+        it 'has the content of the PDF as a File' do
+          expect(attachment.file).to be_a(File)
+          expect(attachment.file.read).to eql(pdf_content)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -91,6 +91,10 @@ module DfidTransition::Transform
           stub_request(:get, original_url).to_return(body: pdf_content)
         end
 
+        after do
+          File.delete("/tmp/#{attachment.filename}")
+        end
+
         it 'has a Future for a #file_future' do
           expect(attachment.file_future).to be_a(Concurrent::Future)
         end

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -37,12 +37,9 @@ module DfidTransition::Transform
       end
 
       describe '#file and #file_future' do
-        it 'has a Future for a #file_future' do
-          expect(attachment.file_future).to be_a(Concurrent::Future)
-        end
-
-        it 'has a value of false when dereferenced with #file' do
-          expect(attachment.file).to be false
+        it 'has no Future at all' do
+          expect { attachment.file_future }.to raise_error(RuntimeError, 'external links cannot be downloaded')
+          expect { attachment.file }.to        raise_error(RuntimeError, 'external links cannot be downloaded')
         end
       end
     end

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -68,6 +68,20 @@ module DfidTransition::Transform
         it 'has the asset manager url' do
           expect(attachment.to_json[:url]).to eql('http://asset.url')
         end
+
+        describe '[:content_type]' do
+          context 'for a PDF' do
+            example { expect(attachment.to_json[:content_type]).to eql('application/pdf') }
+          end
+          context 'for a JPEG' do
+            let(:original_url) { 'http://r4d.dfid.gov.uk/a.jpg' }
+            example { expect(attachment.to_json[:content_type]).to eql('image/jpeg') }
+          end
+          context 'for nothing in particular' do
+            let(:original_url) { 'http://r4d.dfid.gov.uk/erk' }
+            example { expect(attachment.to_json[:content_type]).to be nil }
+          end
+        end
       end
 
       describe '#file and #file_future' do

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -1,4 +1,4 @@
- require 'spec_helper'
+require 'spec_helper'
 require 'dfid-transition/transform/attachment'
 
 module DfidTransition::Transform

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -174,6 +174,9 @@ module DfidTransition::Transform
         it 'has a header with no indents for the abstract' do
           expect(body).to match(/^## Abstract/)
         end
+        it 'has a header with no indents for the links' do
+          expect(body).to match(/^## Links/)
+        end
         it 'has the citation' do
           expect(body).to include(doc.citation)
         end
@@ -183,6 +186,12 @@ module DfidTransition::Transform
         end
         it 'corrects non-standard HTML – the list is separate' do
           expect(body).to include("\n* Hello")
+        end
+        it 'has the onsite link' do
+          expect(body).to include('[InlineAttachment:some.pdf]')
+        end
+        it 'has the offsite link' do
+          expect(body).to include('[offsite.pdf](http://example.com/offsite.pdf)')
         end
 
         context 'the abstract is blank' do

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -110,7 +110,7 @@ module DfidTransition::Transform
         before do
           doc.attachments.each do |attachment|
             allow(attachment).to receive(:asset_response).and_return(
-              double 'response', file_url: 'http://asset.url')
+              double('response', file_url: 'http://asset.url'))
           end
         end
 

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -25,7 +25,8 @@ module DfidTransition::Transform
             'applied to other countries in Africa and Latin America.'\
             '&amp;lt;p&amp;gt;&amp;lt;ul&amp;gt;&amp;lt;li&amp;gt;Hello&amp;lt;/li&amp;gt;&amp;lt;/ul&amp;gt;&amp;lt;/p&amp;gt;'\
             '&amp;lt;/p&amp;gt;'),
-          countryCodes: literal('AZ GB')
+          countryCodes: literal('AZ GB'),
+          uris:         literal('http://r4d.dfid.gov.uk/pdfs/some.pdf http://example.com/offsite.pdf')
         }
       end
 
@@ -106,6 +107,13 @@ module DfidTransition::Transform
       describe '#details' do
         subject(:details) { doc.details }
 
+        before do
+          doc.attachments.each do |attachment|
+            allow(attachment).to receive(:asset_response).and_return(
+              double 'response', file_url: 'http://asset.url')
+          end
+        end
+
         it 'has metadata' do
           expect(details[:metadata]).to eql(doc.metadata)
         end
@@ -113,6 +121,12 @@ module DfidTransition::Transform
         it 'has a non-empty change history list' do
           expect(details[:change_history]).to be_an(Array)
           expect(details[:change_history]).not_to be_empty
+        end
+
+        it 'has onsite attachments only with URLs assigned by asset manager' do
+          attachments_json = details[:attachments]
+          expect(attachments_json.size).to eql(1)
+          expect(attachments_json.first[:url]).to eql('http://asset.url')
         end
 
         describe 'the presented body' do

--- a/spec/lib/govuk/presenters/govspeak_spec.rb
+++ b/spec/lib/govuk/presenters/govspeak_spec.rb
@@ -1,11 +1,26 @@
 require 'spec_helper'
 require 'govuk/presenters/govspeak'
+require 'dfid-transition/transform/attachment'
 
 describe Govuk::Presenters::Govspeak do
-  subject(:rendered) { Govuk::Presenters::Govspeak.present(govspeak) }
+  Attachment = DfidTransition::Transform::Attachment
+  let(:attachments) { [] }
 
-  context 'valid govspeak is given' do
-    let(:govspeak) { "## A header\nsome text" }
+  subject(:rendered) { Govuk::Presenters::Govspeak.new(govspeak, attachments).present }
+
+  context 'valid govspeak and attachments are given' do
+    let(:govspeak) {
+      "## A header\nsome text\n#{onsite_attachment.snippet}"
+    }
+    let(:offsite_attachment) do
+      Attachment.new('http://example.com/a.pdf')
+    end
+    let(:onsite_attachment) do
+      Attachment.new('http://r4d.dfid.gov.uk/pdfs/foobar.pdf').tap do |attachment|
+        allow(attachment).to receive(:asset_response).and_return(double(file_url: 'http://asset.url'))
+      end
+    end
+    let(:attachments) { [offsite_attachment, onsite_attachment] }
 
     it 'renders two sections' do
       expect(rendered.size).to eql(2)
@@ -19,6 +34,9 @@ describe Govuk::Presenters::Govspeak do
       it 'has the raw text' do
         expect(section[:content]).to include('## A header')
       end
+      it 'keeps the links as they are' do
+        expect(section[:content]).to include('[InlineAttachment:foobar.pdf]')
+      end
     end
 
     describe 'the second section' do
@@ -28,6 +46,9 @@ describe Govuk::Presenters::Govspeak do
       end
       it 'has the rendered text' do
         expect(section[:content]).to include('<p>some text')
+      end
+      it 'resolves InlineAttachments to external links' do
+        expect(section[:content]).to include('<a rel="external" href="http://asset.url">foobar.pdf</a><')
       end
     end
   end


### PR DESCRIPTION
Download attachments in a limited parallel fashion while publishing research outputs.
- Add `ruby-concurrency` gem so we can use `Future`s for downloads, to try
  and avoid doing lots of waiting inline in one thread
- Add a `Services.asset_manager` for somewhere to put the files
- Add an `Attachment` class that has far too many responsibilities – knows
  whether it's hosted at r4d or is an external link, can download
  itself, and also present itself to specialist-publisher
- Manage `[InlineAttachment:file.pdf]` in the same way as
  specialist-publisher, i.e. send Govspeak as-is but munge the HTML such
  that inline attachment tags are expanded to [real](links)
- Work out content-types in the same way asset-manager does, from extension alone
