### PR TITLE
Add dfid review status

### DIFF
--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -10,9 +10,10 @@ module DfidTransition
           PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
           PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
           PREFIX bibo:    <http://purl.org/ontology/bibo/>
+          PREFIX status:  <http://purl.org/bibo/status/>
 
           SELECT DISTINCT ?output ?date ?abstract ?title ?citation
-            (bound(?peerReviewedExists) AS ?peerReviewed)
+            (EXISTS { ?output bibo:DocumentStatus status:peerReviewed } AS ?peerReviewed)
             (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
             (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
             (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
@@ -26,10 +27,8 @@ module DfidTransition
 
             OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
             OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
-		        OPTIONAL { ?output bibo:DocumentStatus ?peerReviewedExists .
-                       FILTER (?peerReviewedExists = <http://purl.org/bibo/status/peerReviewed>) }
 
-          } GROUP BY ?output ?date ?abstract ?title ?citation ?peerReviewedExists
+          } GROUP BY ?output ?date ?abstract ?title ?citation
           ORDER BY DESC(?date)
           LIMIT 20
         SPARQL

--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -9,11 +9,13 @@ module DfidTransition
           PREFIX ont:     <http://purl.org/ontology/bibo/>
           PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
           PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+          PREFIX bibo:    <http://purl.org/ontology/bibo/>
 
           SELECT DISTINCT ?output ?date ?abstract ?title ?citation
-                          (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
-                          (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
-                          (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
+            (bound(?peerReviewedExists) AS ?peerReviewed)
+            (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
+            (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
+            (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
           WHERE {
             ?output a ont:Article ;
                     dcterms:title ?title ;
@@ -24,8 +26,10 @@ module DfidTransition
 
             OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
             OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
+		        OPTIONAL { ?output bibo:DocumentStatus ?peerReviewedExists .
+                       FILTER (?peerReviewedExists = <http://purl.org/bibo/status/peerReviewed>) }
 
-          } GROUP BY ?output ?date ?abstract ?title ?citation
+          } GROUP BY ?output ?date ?abstract ?title ?citation ?peerReviewedExists
           ORDER BY DESC(?date)
           LIMIT 20
         SPARQL

--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -6,7 +6,6 @@ module DfidTransition
       class Outputs < Base
         QUERY = <<-SPARQL.freeze
           PREFIX dcterms: <http://purl.org/dc/terms/>
-          PREFIX ont:     <http://purl.org/ontology/bibo/>
           PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
           PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
           PREFIX bibo:    <http://purl.org/ontology/bibo/>
@@ -18,12 +17,12 @@ module DfidTransition
             (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
             (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
           WHERE {
-            ?output a ont:Article ;
+            ?output a bibo:Article ;
                     dcterms:title ?title ;
                     dcterms:abstract ?abstract ;
                     dcterms:bibliographicCitation ?citation ;
                     dcterms:date ?date ;
-                    ont:uri ?uri .
+                    bibo:uri ?uri .
 
             OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
             OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -76,7 +76,7 @@ module DfidTransition
           country: countries,
           first_published_at: first_published_at,
           dfid_authors: creators,
-          peer_reviewed: peer_reviewed
+          dfid_review_status: peer_reviewed ? 'peer_reviewed' : 'unreviewed',
         }
       end
 

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -75,7 +75,8 @@ module DfidTransition
         {
           country: countries,
           first_published_at: first_published_at,
-          dfid_authors: creators
+          dfid_authors: creators,
+          peer_reviewed: peer_reviewed
         }
       end
 
@@ -122,6 +123,10 @@ module DfidTransition
 
       def async_download_attachments
         downloads.each(&:file_future)
+      end
+
+      def peer_reviewed
+        solution[:peerReviewed].true?
       end
 
       def abstract

--- a/spec/lib/dfid-transition/load/outputs_spec.rb
+++ b/spec/lib/dfid-transition/load/outputs_spec.rb
@@ -28,6 +28,7 @@ describe DfidTransition::Load::Outputs do
         date:         literal('2016-04-28T09:52:00'),
         title:        literal('Output Title'),
         abstract:     literal('&amp;lt;p&amp;gt;Abstract;lt;/p&amp;gt;'),
+        peerReviewed: boolean(true),
         countryCodes: literal('AZ GB'),
         uris:         literal("#{onsite_pdf} #{offsite_pdf}")
       }

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -111,8 +111,8 @@ module DfidTransition::Transform
         it 'has our first_published_at date' do
           expect(doc.format_specific_metadata[:first_published_at]).to eql(doc.first_published_at)
         end
-        it 'has the doc peer_reviewed status' do
-          expect(doc.format_specific_metadata[:peer_reviewed]).to eql(doc.peer_reviewed)
+        it 'has the document review status' do
+          expect(doc.format_specific_metadata[:dfid_review_status]).to eql('peer_reviewed')
         end
       end
 

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -20,6 +20,7 @@ module DfidTransition::Transform
           title:        literal(' &amp;#8216;And Then He Switched off the Phone&amp;#8217;: Mobile Phones ... '),
           citation:     literal(' Heinlein, R.; Asimov, A. &lt;b&gt;Domestic Violence Law: The Gap Between Legislation and Practice in Cambodia and What Can Be Done About It.&lt;/b&gt; 72 pp. '),
           creators:     literal(' Heinlein, R. | Asimov, A. '),
+          peerReviewed: boolean(true),
           abstract:     literal(
             '&amp;lt;p&amp;gt;This research design and methods paper can be '\
             'applied to other countries in Africa and Latin America.'\
@@ -83,6 +84,19 @@ module DfidTransition::Transform
         expect(doc.first_published_at).to eql('2016-04-28T09:52:00')
       end
 
+      describe '#peer_reviewed' do
+        subject { doc.peer_reviewed }
+
+        context 'it is peer reviewed' do
+          it { is_expected.to be true }
+        end
+
+        context 'it is not peer reviewed' do
+          before { solution_hash[:peerReviewed] = boolean(false) }
+          it     { is_expected.to be false }
+        end
+      end
+
       it 'splits country codes' do
         expect(doc.countries).to eql(%w(AZ GB))
       end
@@ -96,6 +110,9 @@ module DfidTransition::Transform
         end
         it 'has our first_published_at date' do
           expect(doc.format_specific_metadata[:first_published_at]).to eql(doc.first_published_at)
+        end
+        it 'has the doc peer_reviewed status' do
+          expect(doc.format_specific_metadata[:peer_reviewed]).to eql(doc.peer_reviewed)
         end
       end
 

--- a/spec/support/rdf_doubles.rb
+++ b/spec/support/rdf_doubles.rb
@@ -8,4 +8,11 @@ module RDFDoubles
   def uri(value, options = { class: 'RDF::URI' })
     literal(value, options)
   end
+
+  def boolean(value)
+    double('RDF::Literal::Boolean').tap do |boolean|
+      allow(boolean).to receive(:true?).and_return(value)
+      allow(boolean).to receive(:false?).and_return(!value)
+    end
+  end
 end


### PR DESCRIPTION
Gets a true/false value for peerReviewed from the SPARQL based on a `bibo:DocumentStatus` of `dcterms:peerReviewed`. Passes this through via metadata as a `dfid_review_status` facet with one of the values `unreviewed`/`peer_reviewed`
