### PR TITLE
Add dfid document type

### DIFF
--- a/lib/dfid-transition/extract/query/document_types.rb
+++ b/lib/dfid-transition/extract/query/document_types.rb
@@ -1,0 +1,24 @@
+require 'dfid-transition/extract/query/base'
+
+module DfidTransition
+  module Extract
+    module Query
+      class DocumentTypes < Base
+        QUERY = <<-SPARQL.freeze
+          PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+          SELECT DISTINCT ?type ?prefLabel
+          WHERE {
+            ?type skos:inScheme <http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes> ;
+              skos:prefLabel ?prefLabel .
+          }
+          ORDER BY ?prefLabel
+        SPARQL
+
+        def query
+          QUERY
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -12,7 +12,7 @@ module DfidTransition
           PREFIX status:  <http://purl.org/bibo/status/>
           PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
 
-          SELECT DISTINCT ?output ?date ?abstract ?title ?citation
+          SELECT DISTINCT ?output ?date ?type ?abstract ?title ?citation
             (EXISTS { ?output bibo:DocumentStatus status:peerReviewed } AS ?peerReviewed)
             (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
             (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
@@ -20,12 +20,15 @@ module DfidTransition
             (GROUP_CONCAT(DISTINCT(?theme)) AS ?themes)
           WHERE {
             ?output a bibo:Article ;
+                    dcterms:type ?type ;
                     dcterms:title ?title ;
                     dcterms:abstract ?abstract ;
                     dcterms:bibliographicCitation ?citation ;
                     dcterms:date ?date ;
                     dcterms:subject ?theme ;
                     bibo:uri ?uri .
+
+            FILTER ( ?type != 'text' )
 
             {
               ?theme skos:inScheme <http://r4d.dfid.gov.uk/rdf/skos/Themes>
@@ -35,7 +38,7 @@ module DfidTransition
             OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
             OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
 
-          } GROUP BY ?output ?date ?abstract ?title ?citation
+          } GROUP BY ?output ?date ?type ?abstract ?title ?citation
           ORDER BY DESC(?date)
           LIMIT 20
         SPARQL

--- a/lib/dfid-transition/patch/govuk_content_schemas/base.rb
+++ b/lib/dfid-transition/patch/govuk_content_schemas/base.rb
@@ -7,7 +7,15 @@ module DfidTransition
       class Base < Patcher
       private
 
-        def relative_path
+      def dfid_properties
+        schema_hash.dig(*%w(
+            definitions
+            dfid_research_output_metadata
+            properties
+          ))
+      end
+
+      def relative_path
           File.expand_path(
             File.join(
               Dir.pwd,

--- a/lib/dfid-transition/patch/govuk_content_schemas/base.rb
+++ b/lib/dfid-transition/patch/govuk_content_schemas/base.rb
@@ -7,15 +7,15 @@ module DfidTransition
       class Base < Patcher
       private
 
-      def dfid_properties
-        schema_hash.dig(*%w(
-            definitions
-            dfid_research_output_metadata
-            properties
-          ))
-      end
+        def dfid_properties
+          schema_hash.dig(*%w(
+              definitions
+              dfid_research_output_metadata
+              properties
+            ))
+        end
 
-      def relative_path
+        def relative_path
           File.expand_path(
             File.join(
               Dir.pwd,

--- a/lib/dfid-transition/patch/govuk_content_schemas/document_types.rb
+++ b/lib/dfid-transition/patch/govuk_content_schemas/document_types.rb
@@ -1,0 +1,30 @@
+require 'dfid-transition/transform/document_types'
+require 'dfid-transition/patch/govuk_content_schemas/base'
+
+module DfidTransition
+  module Patch
+    module GovukContentSchemas
+      class DocumentTypes < Base
+        include DfidTransition::Transform::DocumentTypes
+
+        def mutate_schema
+          dfid_properties['dfid_document_types'] = {
+            'type' => 'string',
+            'items' => {
+              'type' => 'string',
+              'enum' => document_type_identifiers
+            }
+          }
+        end
+
+      private
+
+        def document_type_identifiers
+          document_types_query.solutions.map do |solution|
+            parameterize(solution[:type].to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/patch/govuk_content_schemas/themes.rb
+++ b/lib/dfid-transition/patch/govuk_content_schemas/themes.rb
@@ -24,14 +24,6 @@ module DfidTransition
             parameterize(solution[:theme].to_s)
           end
         end
-
-        def dfid_properties
-          schema_hash.dig(*%w(
-            definitions
-            dfid_research_output_metadata
-            properties
-          ))
-        end
       end
     end
   end

--- a/lib/dfid-transition/patch/rummager/document_types.rb
+++ b/lib/dfid-transition/patch/rummager/document_types.rb
@@ -1,0 +1,31 @@
+require 'dfid-transition/extract/query/document_types'
+require 'dfid-transition/patch/rummager/base'
+require 'dfid-transition/transform/document_types'
+
+module DfidTransition
+  module Patch
+    module Rummager
+      class DocumentTypes < Base
+        include DfidTransition::Transform::DocumentTypes
+
+        def mutate_schema
+          add_document_type_field
+          add_document_type_expansions
+        end
+
+      private
+
+        def add_document_type_field
+          unless schema_hash.fetch('fields').include?('dfid_document_type')
+            schema_hash.fetch('fields') << 'dfid_document_type'
+          end
+        end
+
+        def add_document_type_expansions
+          schema_hash['expanded_search_result_fields']['dfid_document_type'] =
+            transform_to_label_value(document_types_query.solutions)
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/patch/specialist_publisher/document_types.rb
+++ b/lib/dfid-transition/patch/specialist_publisher/document_types.rb
@@ -1,0 +1,23 @@
+require 'dfid-transition/transform/document_types'
+require 'dfid-transition/patch/specialist_publisher/base'
+
+module DfidTransition
+  module Patch
+    module SpecialistPublisher
+      class DocumentTypes < Base
+        include DfidTransition::Transform::DocumentTypes
+
+        def mutate_schema
+          document_type_facet['allowed_values'] =
+            transform_to_label_value(document_types_query.solutions)
+        end
+
+      private
+
+        def document_type_facet
+          facet('dfid_document_type')
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -74,10 +74,15 @@ module DfidTransition
         solution[:countryCodes].to_s.split(' ')
       end
 
+      def dfid_document_type
+        parameterize(solution[:type].to_s)
+      end
+
       def format_specific_metadata
         {
           country: countries,
           first_published_at: first_published_at,
+          dfid_document_type: dfid_document_type,
           dfid_authors: creators,
           dfid_review_status: peer_reviewed ? 'peer_reviewed' : 'unreviewed',
           dfid_theme: theme_identifiers

--- a/lib/dfid-transition/transform/document_types.rb
+++ b/lib/dfid-transition/transform/document_types.rb
@@ -1,0 +1,34 @@
+require 'dfid-transition/extract/query/document_types'
+
+module DfidTransition
+  module Transform
+    ##
+    # For patchers that need to query document types and transform those
+    # values
+    #
+    module DocumentTypes
+      def document_types_query
+        @document_types_query ||= DfidTransition::Extract::Query::DocumentTypes.new
+      end
+
+      def transform_to_label_value(r4d_solutions)
+        r4d_solutions.map do |solution|
+          type_slug = parameterize(solution['type'].to_s)
+
+          {
+            value: type_slug,
+            label: solution['prefLabel'].to_s
+          }
+        end
+      end
+
+      def parameterize(type_url)
+        type_url.
+          sub(%r{http://.*#}, ''). # Strip http://....#
+          gsub('/', '_').          # underscore slashes
+          gsub('%20', '_').        # underscore escaped spaces
+          downcase
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/transform/document_types.rb
+++ b/lib/dfid-transition/transform/document_types.rb
@@ -25,7 +25,7 @@ module DfidTransition
       def parameterize(type_url)
         type_url.
           sub(%r{http://.*#}, ''). # Strip http://....#
-          gsub('/', '_').          # underscore slashes
+          tr('/', '_').            # underscore slashes
           gsub('%20', '_').        # underscore escaped spaces
           downcase
       end

--- a/lib/tasks/patch/document_types.rake
+++ b/lib/tasks/patch/document_types.rake
@@ -1,10 +1,12 @@
 require 'dfid-transition/patch/rummager/document_types'
 require 'dfid-transition/patch/specialist_publisher/document_types'
+require 'dfid-transition/patch/govuk_content_schemas/document_types'
 
 namespace :patch do
   desc 'Patch the DFID schema with document types from the R4D SKOS'
   task :types do
     DfidTransition::Patch::SpecialistPublisher::DocumentTypes.new.run
     DfidTransition::Patch::Rummager::DocumentTypes.new.run
+    DfidTransition::Patch::GovukContentSchemas::DocumentTypes.new.run
   end
 end

--- a/lib/tasks/patch/document_types.rake
+++ b/lib/tasks/patch/document_types.rake
@@ -1,0 +1,8 @@
+require 'dfid-transition/patch/rummager/document_types'
+
+namespace :patch do
+  desc 'Patch the DFID schema with document types from the R4D SKOS'
+  task :types do
+    DfidTransition::Patch::Rummager::DocumentTypes.new.run
+  end
+end

--- a/lib/tasks/patch/document_types.rake
+++ b/lib/tasks/patch/document_types.rake
@@ -1,8 +1,10 @@
 require 'dfid-transition/patch/rummager/document_types'
+require 'dfid-transition/patch/specialist_publisher/document_types'
 
 namespace :patch do
   desc 'Patch the DFID schema with document types from the R4D SKOS'
   task :types do
+    DfidTransition::Patch::SpecialistPublisher::DocumentTypes.new.run
     DfidTransition::Patch::Rummager::DocumentTypes.new.run
   end
 end

--- a/spec/fixtures/schemas/specialist_publisher/dfid_research_outputs_src.json
+++ b/spec/fixtures/schemas/specialist_publisher/dfid_research_outputs_src.json
@@ -28,6 +28,17 @@
         ]
     },
     {
+        "key": "dfid_document_type",
+        "name": "Document Type",
+        "type": "text",
+        "preposition": "of type",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {"label": "Book Chapter", "value": "book_chapter"}
+        ]
+    },
+    {
         "key": "country",
         "name": "Country",
         "type": "text",

--- a/spec/fixtures/service-results/r4d_skos_document_types.rdf
+++ b/spec/fixtures/service-results/r4d_skos_document_types.rdf
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF 
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#" 
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+            <skos:ConceptScheme rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes">
+                <dc:title>R4D Document Types</dc:title>
+                <dc:description>A controlled vocabulary of research document types primarily to assist in migration to GOV.UK</dc:description>
+                <dc:creator>CABI</dc:creator>
+                <dc:date>2016-07-03</dc:date>
+                <dc:language>en-gb</dc:language>
+            </skos:ConceptScheme>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Abstract">
+                <skos:prefLabel>Abstract</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Academic%20Thesis">
+                <skos:prefLabel>Academic Thesis</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Annual%20Report">
+                <skos:prefLabel>Annual Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Audio">
+                <skos:prefLabel>Audio</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Bibliography">
+                <skos:prefLabel>Bibliography</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Blog">
+                <skos:prefLabel>Blog</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Book">
+                <skos:prefLabel>Book</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Book%20Chapter">
+                <skos:prefLabel>Book Chapter</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Briefing">
+                <skos:prefLabel>Briefing</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Bulletin">
+                <skos:prefLabel>Bulletin</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Bulletin%20Article">
+                <skos:prefLabel>Bulletin Article</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Case%20Study">
+                <skos:prefLabel>Case Study</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#CD-ROM">
+                <skos:prefLabel>CD-ROM</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Computer%20Software">
+                <skos:prefLabel>Computer Software</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Conference%20Paper">
+                <skos:prefLabel>Conference Paper</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Conference%20Poster">
+                <skos:prefLabel>Conference Poster</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Conference%20Proceedings">
+                <skos:prefLabel>Conference Proceedings</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Country%20Report">
+                <skos:prefLabel>Country Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Dataset">
+                <skos:prefLabel>Dataset</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Discussion%20Paper">
+                <skos:prefLabel>Discussion Paper</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Document">
+                <skos:prefLabel>Document</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Draft">
+                <skos:prefLabel>Draft</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#DVD">
+                <skos:prefLabel>DVD</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Evaluation%20Report">
+                <skos:prefLabel>Evaluation Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Event%20(Miscellaneous)">
+                <skos:prefLabel>Event (Miscellaneous)</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Extension%20Leaflet/Booklet">
+                <skos:prefLabel>Extension Leaflet/Booklet</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Fact%20Sheet">
+                <skos:prefLabel>Fact Sheet</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Flyer">
+                <skos:prefLabel>Flyer</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Highlights">
+                <skos:prefLabel>Highlights</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Inception%20Report">
+                <skos:prefLabel>Inception Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Interim%20Report">
+                <skos:prefLabel>Interim Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Journal%20Article">
+                <skos:prefLabel>Journal Article</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Journal%20Correspondence">
+                <skos:prefLabel>Journal Correspondence</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Journal%20Editorial/Commentary">
+                <skos:prefLabel>Journal Editorial/Commentary</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Journal%20Issue">
+                <skos:prefLabel>Journal Issue</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Key%20Document">
+                <skos:prefLabel>Key Document</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Lessons%20Learned">
+                <skos:prefLabel>Lessons Learned</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Literature%20Review">
+                <skos:prefLabel>Literature Review</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Magazine/Newsletter">
+                <skos:prefLabel>Magazine/Newsletter</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Magazine/Newsletter/Newspaper%20Article">
+                <skos:prefLabel>Magazine/Newsletter/Newspaper Article</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Manual">
+                <skos:prefLabel>Manual</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Map">
+                <skos:prefLabel>Map</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Media">
+                <skos:prefLabel>Media</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Meeting">
+                <skos:prefLabel>Meeting</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Meeting%20Report">
+                <skos:prefLabel>Meeting Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#News">
+                <skos:prefLabel>News</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Oral%20Presentation">
+                <skos:prefLabel>Oral Presentation</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Poster">
+                <skos:prefLabel>Poster</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#PowerPoint%20Presentation">
+                <skos:prefLabel>PowerPoint Presentation</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Protocol">
+                <skos:prefLabel>Protocol</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Questionnaire">
+                <skos:prefLabel>Questionnaire</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Radio">
+                <skos:prefLabel>Radio</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Report">
+                <skos:prefLabel>Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Research%20Paper">
+                <skos:prefLabel>Research Paper</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Systematic%20Review">
+                <skos:prefLabel>Systematic Review</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Technical%20Report">
+                <skos:prefLabel>Technical Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Television">
+                <skos:prefLabel>Television</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Thematic%20Summary">
+                <skos:prefLabel>Thematic Summary</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Tool%20kit">
+                <skos:prefLabel>Tool kit</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Training%20Event">
+                <skos:prefLabel>Training Event</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Training%20Materials">
+                <skos:prefLabel>Training Materials</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Video">
+                <skos:prefLabel>Video</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Visit">
+                <skos:prefLabel>Visit</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Visit%20Report">
+                <skos:prefLabel>Visit Report</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Web%20Content">
+                <skos:prefLabel>Web Content</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+
+            <skos:Concept rdf:about="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Working%20Paper">
+                <skos:prefLabel>Working Paper</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes"/>
+            </skos:Concept>
+</rdf:RDF>

--- a/spec/lib/dfid-transition/patch/govuk_content_schemas/document_types_spec.rb
+++ b/spec/lib/dfid-transition/patch/govuk_content_schemas/document_types_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'dfid-transition/patch/govuk_content_schemas/document_types'
+require 'rdf/rdfxml'
+
+describe DfidTransition::Patch::GovukContentSchemas::DocumentTypes do
+  let(:patch_location) { nil }
+  subject(:patch) { DfidTransition::Patch::GovukContentSchemas::DocumentTypes.new(patch_location) }
+
+  it_behaves_like "holds onto the location of a schema file and warns us if it is not there"
+
+  describe '#run' do
+    let(:patch_location) { 'spec/fixtures/schemas/govuk_content_schemas/details.json' }
+    let(:r4d_skos_document_types_repo) do
+      RDF::Repository.load('spec/fixtures/service-results/r4d_skos_document_types.rdf')
+    end
+
+    before do
+      allow(patch).to receive(:document_types_query).and_return(
+        DfidTransition::Extract::Query::DocumentTypes.new(
+          SPARQL::Client.new(r4d_skos_document_types_repo)
+        )
+      )
+
+      FileUtils.cp(
+        'spec/fixtures/schemas/govuk_content_schemas/details_src.json',
+        patch_location)
+
+      patch.run
+    end
+
+    after do
+      File.delete(patch_location)
+    end
+
+    let(:schema) { JSON.parse(File.read(patch_location)) }
+
+    subject(:dfid_document_types) do
+      schema.dig(*%w(definitions dfid_research_output_metadata properties dfid_document_types))
+    end
+
+    it 'is a single-valued type' do
+      expect(dfid_document_types['type']).to eql('string')
+    end
+
+    describe 'the items' do
+      subject(:items) { dfid_document_types['items'] }
+
+      it 'has a string type' do
+        expect(items['type']).to eql('string')
+      end
+
+      it 'adds document_types data to the schema' do
+        expect(items['enum'].count).to eq(66)
+      end
+
+      it 'underscores/downcases values' do
+        expect(items['enum']).to include('magazine_newsletter_newspaper_article')
+      end
+    end
+  end
+end

--- a/spec/lib/dfid-transition/patch/rummager/document_types_spec.rb
+++ b/spec/lib/dfid-transition/patch/rummager/document_types_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'json'
+require 'rdf/rdfxml'
+require 'dfid-transition/patch/rummager/document_types'
+
+describe DfidTransition::Patch::Rummager::DocumentTypes do
+  it_behaves_like "holds onto the location of a schema file and warns us if it is not there"
+
+  subject(:patcher) { DfidTransition::Patch::Rummager::DocumentTypes.new(patch_location) }
+
+  describe '#run' do
+    context 'the target schema file exists' do
+      let(:schema_src)     { 'spec/fixtures/schemas/rummager/dfid_research_outputs_no_fields.json' }
+      let(:patch_location) { 'spec/fixtures/schemas/rummager/dfid_research_outputs.json' }
+      let(:r4d_skos_document_type_repo) do
+        RDF::Repository.load('spec/fixtures/service-results/r4d_skos_document_types.rdf')
+      end
+
+      before do
+        allow(patcher).to receive(:document_types_query).and_return(
+          DfidTransition::Extract::Query::DocumentTypes.new(
+            SPARQL::Client.new(r4d_skos_document_type_repo)
+          )
+        )
+
+        FileUtils.cp(schema_src, patch_location)
+
+        patcher.run
+      end
+
+      after do
+        File.delete(patch_location)
+      end
+
+      subject(:parsed_json) { JSON.parse(File.read(patch_location)) }
+
+      it 'adds the document type field' do
+        expect(parsed_json['fields']).to include('dfid_document_type')
+      end
+
+      it 'patches the schema with all of the theme labels and values' do
+        theme_expansions = parsed_json.dig('expanded_search_result_fields', 'dfid_document_type')
+        expect(theme_expansions).to include(
+          'value' => 'magazine_newsletter_newspaper_article',
+          'label' => 'Magazine/Newsletter/Newspaper Article'
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/dfid-transition/patch/specialist_publisher/document_types_spec.rb
+++ b/spec/lib/dfid-transition/patch/specialist_publisher/document_types_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'dfid-transition/patch/specialist_publisher/document_types'
+require 'rdf/rdfxml'
+
+describe DfidTransition::Patch::SpecialistPublisher::DocumentTypes do
+  let(:patch_location) { nil }
+  subject(:patch) { DfidTransition::Patch::SpecialistPublisher::DocumentTypes.new(patch_location) }
+
+  it_behaves_like "holds onto the location of a schema file and warns us if it is not there"
+
+  describe '#run' do
+    let(:patch_location) { 'spec/fixtures/schemas/specialist_publisher/dfid_research_outputs.json' }
+    let(:r4d_skos_document_type_repo) do
+      RDF::Repository.load('spec/fixtures/service-results/r4d_skos_document_types.rdf')
+    end
+
+    before do
+      allow(patch).to receive(:document_types_query).and_return(
+        DfidTransition::Extract::Query::DocumentTypes.new(
+          SPARQL::Client.new(r4d_skos_document_type_repo)
+        )
+      )
+
+      FileUtils.cp(
+        'spec/fixtures/schemas/specialist_publisher/dfid_research_outputs_src.json',
+        patch_location)
+
+      patch.run
+    end
+
+    after do
+      File.delete(patch_location)
+    end
+
+    let(:schema) { JSON.parse(File.read(patch_location)) }
+    let(:document_types) { schema['facets'].find { |facet| facet['key'] == 'dfid_document_type' } }
+
+    subject(:allowed_values) { document_types['allowed_values'] }
+
+    it 'adds document_type data to the schema' do
+      expect(allowed_values.count).to eq(66)
+    end
+
+    it 'leaves labels alone and underscores/downcases values' do
+      expect(allowed_values).to include(
+        'label' => 'Magazine/Newsletter/Newspaper Article',
+        'value' => 'magazine_newsletter_newspaper_article'
+      )
+    end
+
+    it 'sorts document_types alphabetically by label' do
+      labels = document_types['allowed_values'].map { |lv| lv['label'] }
+      expect(labels).to eql(labels.sort), 'document_type labels are not sorted'
+    end
+  end
+end

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -16,6 +16,7 @@ module DfidTransition::Transform
       let(:solution_hash) do
         {
           output:       uri(original_url),
+          type:         uri('http://r4d.dfid.gov.uk/rdf/skos/DocumentTypes#Book%20Chapter'),
           date:         literal('2016-04-28T09:52:00'),
           title:        literal(' &amp;#8216;And Then He Switched off the Phone&amp;#8217;: Mobile Phones ... '),
           citation:     literal(' Heinlein, R.; Asimov, A. &lt;b&gt;Domestic Violence Law: The Gap Between Legislation and Practice in Cambodia and What Can Be Done About It.&lt;/b&gt; 72 pp. '),
@@ -166,6 +167,9 @@ module DfidTransition::Transform
 
         it 'has the document type' do
           expect(metadata[:document_type]).to eql('dfid_research_output')
+        end
+        it 'has the DFID document type' do
+          expect(metadata[:dfid_document_type]).to eql('book_chapter')
         end
         it 'has a list of countries' do
           expect(metadata[:country]).to eql(%w(AZ GB))


### PR DESCRIPTION
- Patchers for SPR, rummager and govuk-content-schemas
- Query modification to get the types from SPARQL when importing
- Pass the metadata through to publishing-api/rummager
