### PR TITLE
Attachment loader prototype

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,15 @@ gem 'concurrent-ruby'
 gem 'kramdown'
 gem 'erubis'
 gem 'mime-types'
+gem 'sidekiq'
+gem 'redis-namespace'
 
 group :development, :test do
   gem 'govuk-lint'
   gem 'rspec'
   gem 'webmock'
+end
+
+group :test do
+  gem 'mock_redis'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     builder (3.2.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
+    connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
@@ -56,6 +57,7 @@ GEM
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    mock_redis (0.16.1)
     net-http-persistent (2.9.4)
     netrc (0.11.0)
     nokogiri (1.6.7.2)
@@ -72,6 +74,8 @@ GEM
     rack (1.6.4)
     rack-cache (1.6.1)
       rack (>= 0.4)
+    rack-protection (1.5.3)
+      rack
     rainbow (2.1.0)
     rake (10.5.0)
     rdf (2.0.1)
@@ -92,6 +96,9 @@ GEM
       rdf-xsd (~> 2.0)
     rdf-xsd (2.0.0)
       rdf (~> 2.0)
+    redis (3.3.0)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -123,6 +130,15 @@ GEM
     scss_lint (0.44.0)
       rake (~> 10.0)
       sass (~> 3.4.15)
+    sidekiq (4.1.4)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
+      sinatra (>= 1.4.7)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     slop (3.6.0)
     sparql (2.0.0)
       builder (~> 3.2)
@@ -162,12 +178,15 @@ DEPENDENCIES
   govuk-lint
   kramdown
   mime-types
+  mock_redis
   nokogiri
   pry
   rake
   rdf-rdfxml
+  redis-namespace
   rest-client
   rspec
+  sidekiq
   sparql
   webmock
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,8 +1,21 @@
 require 'redis-namespace'
 
+def _redis_config
+  @redis_config ||= begin
+    redis_config_hash = YAML.load_file('config/redis.yml').symbolize_keys
+
+    namespace = redis_config_hash[:namespace]
+
+    {
+      url: "redis://#{redis_config_hash[:host]}:#{redis_config_hash[:port]}/0",
+      namespace: namespace
+    }
+  end
+end
+
 def _namespaced_redis
   Redis::Namespace.new(
-    'dfid-transition',
-    redis: Redis.new(url: "redis://127.0.0.1:6379/0")
+    _redis_config[:namespace],
+    redis: Redis.new(url: _redis_config[:url])
   )
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,8 @@
+require 'redis-namespace'
+
+def _namespaced_redis
+  Redis::Namespace.new(
+    'dfid-transition',
+    redis: Redis.new(url: "redis://127.0.0.1:6379/0")
+  )
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,8 @@
+require_relative './redis'
+
 require 'sidekiq'
 require 'sidekiq/api'
 
 Sidekiq.configure_client do |config|
-  config.redis = {
-    :namespace => 'dfid-transition-workers',
-    :size => 5
-  }
+  config.redis = _redis_config
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+require 'sidekiq'
+require 'sidekiq/api'
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    :namespace => 'dfid-transition-workers',
+    :size => 5
+  }
+end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,0 +1,3 @@
+host: 127.0.0.1
+port: 6379
+namespace: dfid-transition

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+---
+:concurrency:  16
+:require: ./lib/dfid-transition/workers.rb
+:queues:
+  - default

--- a/lib/dfid-transition/extract/download/attachment.rb
+++ b/lib/dfid-transition/extract/download/attachment.rb
@@ -1,0 +1,34 @@
+$LOAD_PATH.unshift(File.expand_path('../../..', File.dirname(__FILE__), ))
+
+require 'sidekiq'
+require 'dfid-transition/services'
+require 'dfid-transition/transform/attachment'
+
+module DfidTransition
+  module Extract
+    module Download
+      class Attachment
+        include Sidekiq::Worker
+
+        def perform(url)
+          logger.info("Skipping: #{url}") && return if attachment_index.get(url)
+
+          attachment = DfidTransition::Transform::Attachment.new(url)
+
+          asset_response = attachment.save_to(asset_manager)
+          attachment_index.put(url, asset_response)
+        end
+
+      private
+
+        def asset_manager
+          Services.asset_manager
+        end
+
+        def attachment_index
+          Services.attachment_index
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/extract/download/attachment.rb
+++ b/lib/dfid-transition/extract/download/attachment.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.expand_path('../../..', File.dirname(__FILE__), ))
+$LOAD_PATH.unshift(File.expand_path('../../..', File.dirname(__FILE__)))
 
 require 'sidekiq'
 require 'dfid-transition/services'

--- a/lib/dfid-transition/load/attachments.rb
+++ b/lib/dfid-transition/load/attachments.rb
@@ -1,0 +1,35 @@
+require 'dfid-transition/transform/document'
+require 'dfid-transition/extract/download/attachment'
+require 'govuk/presenters/search'
+require 'logger'
+
+module DfidTransition
+  module Load
+    class Attachments
+      attr_reader :logger
+      attr_accessor :asset_manager, :solutions
+
+      def initialize(asset_manager, solutions, logger: Logger.new(STDERR))
+        self.asset_manager = asset_manager
+        self.solutions = solutions
+
+        @logger = logger
+      end
+
+      def run
+        documents.each do |doc|
+          doc.downloads.each do |attachment|
+            DfidTransition::Extract::Download::Attachment.perform_async(attachment.original_url)
+          end
+        end
+      end
+
+    private
+
+      def documents
+        @documents ||=
+          solutions.map { |solution| DfidTransition::Transform::Document.new(solution) }
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/services.rb
+++ b/lib/dfid-transition/services.rb
@@ -3,7 +3,7 @@ require 'gds_api/asset_manager'
 require 'gds_api/rummager'
 
 module DfidTransition
-  class Services
+  module Services
     def self.publishing_api
       @publishing_api ||= GdsApi::PublishingApiV2.new(
         Plek.new.find('publishing-api'),

--- a/lib/dfid-transition/services.rb
+++ b/lib/dfid-transition/services.rb
@@ -1,6 +1,7 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/asset_manager'
 require 'gds_api/rummager'
+require 'dfid-transition/services/attachment_index'
 
 module DfidTransition
   module Services
@@ -20,6 +21,15 @@ module DfidTransition
 
     def self.rummager
       @rummager ||= GdsApi::Rummager.new(Plek.new.find('search'))
+    end
+
+    def self.attachment_index
+      @attachment_index ||= AttachmentIndex.new(redis)
+    end
+
+    def self.redis
+      require_relative '../../config/initializers/redis'
+      @redis ||= _namespaced_redis
     end
   end
 end

--- a/lib/dfid-transition/services/attachment_index.rb
+++ b/lib/dfid-transition/services/attachment_index.rb
@@ -18,7 +18,7 @@ module DfidTransition
         JSON.parse(attachment_status)
       end
 
-      KNOWN_ATTACHMENTS_KEY = 'known-attachments'
+      KNOWN_ATTACHMENTS_KEY = 'known-attachments'.freeze
 
       def put(original_url, asset_response)
         redis.multi do
@@ -27,18 +27,18 @@ module DfidTransition
         end
       end
 
-      private
+    private
 
       def attachment_key(original_url)
         "attachment:#{original_url}"
       end
 
       def present(original_url, asset_response)
-        JSON.generate({
+        JSON.generate(
           original_url:      original_url,
           asset_manager_url: asset_response.id,
           file_url:          asset_response.file_url
-        })
+        )
       end
     end
   end

--- a/lib/dfid-transition/services/attachment_index.rb
+++ b/lib/dfid-transition/services/attachment_index.rb
@@ -1,0 +1,45 @@
+require 'dfid-transition/services'
+
+module DfidTransition
+  module Services
+    ##
+    # Concerns: allows us to look up assets from their original DFID URLs
+    #
+    class AttachmentIndex
+      attr_reader :redis
+
+      def initialize(redis)
+        @redis = redis
+      end
+
+      def get(original_url)
+        attachment_status = redis.get(attachment_key(original_url)) || (return nil)
+
+        JSON.parse(attachment_status)
+      end
+
+      KNOWN_ATTACHMENTS_KEY = 'known-attachments'
+
+      def put(original_url, asset_response)
+        redis.multi do
+          redis.set(attachment_key(original_url), present(original_url, asset_response))
+          redis.sadd(KNOWN_ATTACHMENTS_KEY, original_url)
+        end
+      end
+
+      private
+
+      def attachment_key(original_url)
+        "attachment:#{original_url}"
+      end
+
+      def present(original_url, asset_response)
+        JSON.generate({
+          original_url:      original_url,
+          asset_manager_url: asset_response.id,
+          file_url:          asset_response.file_url
+        })
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -3,6 +3,7 @@ require 'concurrent/future'
 require 'securerandom'
 require 'rest-client'
 require 'mime-types'
+require 'ostruct'
 
 module DfidTransition
   module Transform
@@ -64,6 +65,10 @@ module DfidTransition
 
       def save_to(asset_manager)
         @asset_response = asset_manager.create_asset(file: file)
+      end
+
+      def details_from_index(details)
+        @asset_response = OpenStruct.new(details)
       end
 
       def to_json

--- a/lib/dfid-transition/workers.rb
+++ b/lib/dfid-transition/workers.rb
@@ -1,0 +1,10 @@
+{
+  lib: '..',
+  app: '../..'
+}.each_value do |path|
+  $LOAD_PATH.unshift(File.expand_path(path, File.dirname(__FILE__)))
+end
+
+require 'config/initializers/sidekiq'
+
+require 'dfid-transition/extract/download/attachment'

--- a/lib/tasks/load/attachments.rake
+++ b/lib/tasks/load/attachments.rake
@@ -1,0 +1,19 @@
+require 'dfid-transition/extract/query/outputs'
+require 'dfid-transition/load/attachments'
+require 'dfid-transition/services'
+
+namespace :load do
+  desc 'Load DFID attachments with attachment URIs from the SPARQL endpoint'
+  task :attachments do
+    module DfidTransition
+      output_solutions = Extract::Query::Outputs.new.solutions
+
+      attachments_loader = Load::Attachments.new(
+        Services.asset_manager,
+        output_solutions
+      )
+
+      attachments_loader.run
+    end
+  end
+end

--- a/lib/tasks/load/outputs.rake
+++ b/lib/tasks/load/outputs.rake
@@ -11,6 +11,7 @@ namespace :load do
         Services.publishing_api,
         Services.rummager,
         Services.asset_manager,
+        Services.attachment_index,
         output_solutions
       )
       loader.run

--- a/lib/tasks/workers/run.rake
+++ b/lib/tasks/workers/run.rake
@@ -1,0 +1,6 @@
+namespace :workers do
+  desc 'Start all the workers referenced in dfid-transition/workers.rb'
+  task :run do
+    exec('bundle exec sidekiq -C ./config/sidekiq.yml')
+  end
+end

--- a/spec/lib/dfid-transition/extract/download/attachment_spec.rb
+++ b/spec/lib/dfid-transition/extract/download/attachment_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'dfid-transition/extract/download/attachment'
+
+describe DfidTransition::Extract::Download::Attachment do
+  describe '#perform' do
+    let(:attachment_index) { spy 'DfidTransition::Extract::Transform::AttachmentIndex' }
+    let(:logger)           { spy 'Logger' }
+    let(:asset_manager)    { spy 'GdsApi::AssetManager' }
+    let(:original_url)     { 'http://r4d.dfid.gov.uk/file.pdf' }
+
+    before do
+      allow(subject).to receive(:asset_manager).and_return(asset_manager)
+      allow(subject).to receive(:attachment_index).and_return(attachment_index)
+      allow(subject).to receive(:logger).and_return(logger)
+    end
+
+    context 'the URL is already in the index' do
+      before do
+        allow(attachment_index).to receive(:get).with(original_url).and_return(totally: 'exists')
+
+        subject.perform(original_url)
+      end
+
+      it 'logs that it is skipping' do
+        expect(logger).to have_received(:info).with("Skipping: #{original_url}")
+      end
+
+      it 'does nothing else' do
+        expect(asset_manager).not_to have_received(:create_asset)
+      end
+    end
+
+    context 'the URL is not in the index and we can download it ok' do
+      let(:asset_response) { double 'Hash' }
+
+      before do
+        allow(attachment_index).to receive(:get).with(original_url).and_return(nil)
+        stub_request(:get, original_url).to_return(status: 200, body: 'Some content')
+        allow(asset_manager).to receive(:create_asset).and_return(asset_response)
+
+        subject.perform(original_url)
+      end
+
+      it 'uploads to asset manager' do
+        expect(asset_manager).to have_received(:create_asset).with(file: instance_of(File))
+      end
+
+      it 'updates the index' do
+        expect(attachment_index).to have_received(:put).with(original_url, asset_response)
+      end
+    end
+  end
+end

--- a/spec/lib/dfid-transition/load/outputs_spec.rb
+++ b/spec/lib/dfid-transition/load/outputs_spec.rb
@@ -51,7 +51,10 @@ describe DfidTransition::Load::Outputs do
 
     after do
       loader.send(:documents).each do |document|
-        document.downloads.each { |download| File.delete("/tmp/#{download.filename}") }
+        document.downloads.each do |download|
+          filename = "/tmp/#{download.filename}"
+          File.delete(filename) if File.exist?(filename)
+        end
       end
     end
 

--- a/spec/lib/dfid-transition/services/attachment_index_spec.rb
+++ b/spec/lib/dfid-transition/services/attachment_index_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+require 'dfid-transition/services/attachment_index'
+require 'mock_redis'
+
+describe DfidTransition::Services::AttachmentIndex do
+  AttachmentIndex = DfidTransition::Services::AttachmentIndex
+
+  let(:redis) { MockRedis.new }
+  subject(:attachment_index) { AttachmentIndex.new(redis) }
+
+  let(:original_url) { 'http://example.com/a.pdf' }
+
+  let(:asset_response) do
+    double(
+      'GDSApi::Response',
+      '_response_info' => {'status' => 'created'},
+      'id' => 'http://asset-manager.dev.gov.uk/assets/5788a087759b74360900006c',
+      'name' => 'a.pdf',
+      'content_type' => 'application/pdf',
+      'file_url' => 'http://assets-origin.dev.gov.uk/media/5788a087759b74360900006c/60953_DV_Law_Prelim_Report_2014.pdf',
+      'state' => 'unscanned'
+    )
+  end
+
+  describe '.put' do
+    context 'an original_url and an asset response is given' do
+      before { @response = attachment_index.put(original_url, asset_response) }
+
+      it 'writes multiply OK, true' do
+        expect(@response).to eql(['OK', true])
+      end
+
+      it 'adds to the dfid-transition-known-attachments hash' do
+        expect(redis.smembers(AttachmentIndex::KNOWN_ATTACHMENTS_KEY)).to eql([original_url])
+      end
+    end
+  end
+
+  describe '.get' do
+    context 'there is no item in the index' do
+      it 'returns nil' do
+        expect(attachment_index.get('http://example.com/i.dont.exist.pdf')).to eql(nil)
+      end
+    end
+
+    context 'there is an item in the index' do
+      before do
+        attachment_index.put(original_url, asset_response)
+      end
+
+      subject(:attachment_status) do
+        attachment_index.get(original_url)
+      end
+
+      describe 'The returned attachment status' do
+        it 'has an original_url' do
+          expect(attachment_status['original_url']).to eql(original_url)
+        end
+
+        it 'has the asset manager url' do
+          expect(attachment_status['asset_manager_url']).to eql(asset_response.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/dfid-transition/services/attachment_index_spec.rb
+++ b/spec/lib/dfid-transition/services/attachment_index_spec.rb
@@ -13,7 +13,7 @@ describe DfidTransition::Services::AttachmentIndex do
   let(:asset_response) do
     double(
       'GDSApi::Response',
-      '_response_info' => {'status' => 'created'},
+      '_response_info' => { 'status' => 'created' },
       'id' => 'http://asset-manager.dev.gov.uk/assets/5788a087759b74360900006c',
       'name' => 'a.pdf',
       'content_type' => 'application/pdf',

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -59,6 +59,18 @@ module DfidTransition::Transform
         expect(attachment.snippet).to eql('[InlineAttachment:file.pdf]')
       end
 
+      describe '#details_from_index' do
+        it 'allows the mocking of the asset response' do
+          details_from_index = {
+            'file_url' => 'http://some.url'
+          }
+          attachment.details_from_index(details_from_index)
+          asset_response = attachment.send(:asset_response)
+
+          expect(asset_response.file_url).to eql('http://some.url')
+        end
+      end
+
       describe '#to_json' do
         before do
           allow(attachment).to receive(:asset_response).and_return(


### PR DESCRIPTION
Decouples downloads from the import process by using an `AttachmentIndex`.

The `AttachmentIndex` is populated by running `rake load:attachments`. This will get all `dcterms:uri` subjects associated with research outputs and queue those hosted at `r4d.dfid.gov.uk` for downloading via the `DfidTransition::Extract::Download::Attachment` Sidekiq job.

The Sidekiq job will then download the attachment and put its details in a namespaced Redis index with a key like `dfid-transition:attachments:http://r4d.dfid.gov.uk/pdfs/a.pdf`. As a convenience, and to assist with monitoring, a Redis set `dfid-transition:known-attachments` will also have the original URL added. The URL is known to contain no spaces, and is not escaped in any way.

When `load:outputs` runs and publishes a research output, it will first check the index and use the `file_url` contained therein to generate its links.
