### PR TITLE
Config for sidekiq

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -2,7 +2,11 @@ require 'redis-namespace'
 
 def _redis_config
   @redis_config ||= begin
-    redis_config_hash = YAML.load_file('config/redis.yml').symbolize_keys
+    redis_config_hash = {
+      host: ENV["REDIS_HOST"] || "127.0.0.1",
+      port: ENV["REDIS_PORT"] || 6379,
+      namespace: ENV["REDIS_NAMESPACE"] || "dfid-transition",
+    }
 
     namespace = redis_config_hash[:namespace]
 

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,0 @@
-host: 127.0.0.1
-port: 6379
-namespace: dfid-transition

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,7 @@
 ---
+:verbose: true
 :concurrency:  16
 :require: ./lib/dfid-transition/workers.rb
+:logfile: ./log/sidekiq.log
 :queues:
   - default


### PR DESCRIPTION
Make redis/sikekiq config govuk app-compatible
- Add a Procfile for worker start
- Make redis read from ENV, not YAML
- Add logging settings
## Related PRs:

https://github.com/alphagov/govuk-puppet/pull/4660
