### PR TITLE
Add a rake task to dump mappings for transition

### DIFF
--- a/lib/dfid-transition/transform/mappings.rb
+++ b/lib/dfid-transition/transform/mappings.rb
@@ -1,0 +1,37 @@
+require 'dfid-transition/transform/document'
+
+module DfidTransition
+  module Transform
+    ##
+    # Given a set of output solutions with URIs and an attachment index,
+    # #dump_csv will output a transition-compatible CSV to $stdout
+    # (or `output_to`, if supplied)
+    #
+    class Mappings
+      def initialize(attachment_index, solutions, output_to: $stdout)
+        @attachment_index = attachment_index
+        @solutions = solutions
+        @output = output_to
+      end
+
+      HEADER_ROW = "Old URL, New URL\n".freeze
+
+      def dump_csv
+        @output.puts HEADER_ROW
+
+        @solutions.each do |solution|
+          doc = DfidTransition::Transform::Document.new(solution)
+
+          @output.puts "#{doc.original_url},https://gov.uk/dfid-research-outputs/#{doc.original_id}\n"
+
+          doc.downloads.each do |download|
+            existing_details = @attachment_index.get(download.original_url.to_s)
+            if existing_details
+              @output.puts "#{download.original_url},#{existing_details['file_url']}\n"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/list/mappings.rake
+++ b/lib/tasks/list/mappings.rake
@@ -1,0 +1,19 @@
+require 'dfid-transition/extract/query/outputs'
+require 'dfid-transition/services'
+require 'dfid-transition/transform/mappings'
+
+namespace :list do
+  desc 'List transition mappings for old URLs'
+  task :mappings do
+    module DfidTransition
+      output_query = Extract::Query::Outputs.new
+
+      mappings = Transform::Mappings.new(
+        Services.attachment_index,
+        output_query.solutions
+      )
+
+      mappings.dump_csv
+    end
+  end
+end

--- a/spec/lib/dfid-transition/transform/mappings_spec.rb
+++ b/spec/lib/dfid-transition/transform/mappings_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+require 'dfid-transition/transform/mappings'
+
+describe DfidTransition::Transform::Mappings do
+  let(:attachment_index)   { double 'DfidTransition::Transform::AttachmentIndex' }
+  let(:attachment_details) { nil }
+
+  let(:stdout) { spy '$stdout' }
+  let(:mappings) do
+    DfidTransition::Transform::Mappings.new(
+      attachment_index, solutions, output_to: stdout)
+  end
+
+  describe '#to_csv' do
+    context 'solutions are an empty set' do
+      let(:solutions) { [] }
+
+      before { mappings.dump_csv }
+
+      it 'generates only the header' do
+        expect(stdout).to have_received(:puts).with("Old URL, New URL\n")
+      end
+    end
+
+    context 'solutions has a valid solution in it' do
+      include RDFDoubles
+
+      let(:onsite_pdf)         { 'http://r4d.dfid.gov.uk/pdfs/onsite.pdf' }
+      let(:offsite_pdf)        { 'http://example.com/offsite.pdf' }
+      let(:attachment_details) { nil }
+
+      let(:solutions) do
+        [{
+          output:       uri('http://original_url/1234/'),
+          uris:         literal("#{onsite_pdf} #{offsite_pdf}"),
+        }]
+      end
+
+      before do
+        allow(attachment_index).to receive(:get).and_return(attachment_details)
+
+        mappings.dump_csv
+      end
+
+      it 'still has the header' do
+        expect(stdout).to have_received(:puts).with("Old URL, New URL\n")
+      end
+
+      it 'has a mapping from the old to the new document URL' do
+        expect(stdout).to have_received(:puts).with(
+          "http://original_url/1234/,https://gov.uk/dfid-research-outputs/1234\n"
+        )
+      end
+
+      context 'onsite PDF has no entry in the AttachmentIndex' do
+        it 'omits the mapping for the onsite PDF' do
+          expect(stdout).not_to have_received(:puts).with(onsite_pdf)
+        end
+      end
+
+      context 'onsite PDF is in the AttachmentIndex' do
+        let(:attachment_details) {
+          {
+            'file_url' => 'https://new.attachment.url'
+          }
+        }
+
+        it 'has a mapping for the onsite PDF' do
+          expect(stdout).to have_received(:puts).with(
+            "http://r4d.dfid.gov.uk/pdfs/onsite.pdf,https://new.attachment.url\n"
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dump transition-compatible CSV for Old Url -> New URL mappings so
that we redirect correctly for old PDFs and documents.

Uses the same query as for Outputs at present, which is inefficient, but we probably don't care.
