### PR TITLE
Add sidekiq monitor Rack app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bundle exec rails s -p 3124
 worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,4 @@
+require_relative 'config/initializers/sidekiq'
+
+require 'sidekiq/web'
+run Sidekiq::Web


### PR DESCRIPTION
Port 3124 is already reserved. Let's use it for something useful,
like monitoring our queues.
