### PR TITLE
Make limit configurable

### DIFF
--- a/lib/dfid-transition/extract/query/base.rb
+++ b/lib/dfid-transition/extract/query/base.rb
@@ -14,8 +14,11 @@ module DfidTransition
       end
 
       class Base
-        def initialize(client = nil)
-          @client = client
+        attr_reader :options
+
+        def initialize(options = {})
+          @client = options[:client]
+          @options = options
         end
 
         def query

--- a/lib/dfid-transition/extract/query/outputs.rb
+++ b/lib/dfid-transition/extract/query/outputs.rb
@@ -4,47 +4,53 @@ module DfidTransition
   module Extract
     module Query
       class Outputs < Base
-        QUERY = <<-SPARQL.freeze
-          PREFIX dcterms: <http://purl.org/dc/terms/>
-          PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
-          PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
-          PREFIX bibo:    <http://purl.org/ontology/bibo/>
-          PREFIX status:  <http://purl.org/bibo/status/>
-          PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
-
-          SELECT DISTINCT ?output ?date ?type ?abstract ?title ?citation
-            (EXISTS { ?output bibo:DocumentStatus status:peerReviewed } AS ?peerReviewed)
-            (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
-            (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
-            (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
-            (GROUP_CONCAT(DISTINCT(?theme)) AS ?themes)
-          WHERE {
-            ?output a bibo:Article ;
-                    dcterms:type ?type ;
-                    dcterms:title ?title ;
-                    dcterms:abstract ?abstract ;
-                    dcterms:bibliographicCitation ?citation ;
-                    dcterms:date ?date ;
-                    dcterms:subject ?theme ;
-                    bibo:uri ?uri .
-
-            FILTER ( ?type != 'text' )
-
-            {
-              ?theme skos:inScheme <http://r4d.dfid.gov.uk/rdf/skos/Themes>
-              FILTER EXISTS { ?theme skos:narrower ?narrowerTheme }
-            }
-
-            OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
-            OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
-
-          } GROUP BY ?output ?date ?type ?abstract ?title ?citation
-          ORDER BY DESC(?date)
-          LIMIT 20
-        SPARQL
+        DEFAULT_LIMIT = 20
 
         def query
-          QUERY
+          <<-SPARQL
+            PREFIX dcterms: <http://purl.org/dc/terms/>
+            PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
+            PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+            PREFIX bibo:    <http://purl.org/ontology/bibo/>
+            PREFIX status:  <http://purl.org/bibo/status/>
+            PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+            SELECT DISTINCT ?output ?date ?type ?abstract ?title ?citation
+              (EXISTS { ?output bibo:DocumentStatus status:peerReviewed } AS ?peerReviewed)
+              (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
+              (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
+              (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
+              (GROUP_CONCAT(DISTINCT(?theme)) AS ?themes)
+            WHERE {
+              ?output a bibo:Article ;
+                      dcterms:type ?type ;
+                      dcterms:title ?title ;
+                      dcterms:abstract ?abstract ;
+                      dcterms:bibliographicCitation ?citation ;
+                      dcterms:date ?date ;
+                      dcterms:subject ?theme ;
+                      bibo:uri ?uri .
+
+              FILTER ( ?type != 'text' )
+
+              {
+                ?theme skos:inScheme <http://r4d.dfid.gov.uk/rdf/skos/Themes>
+                FILTER EXISTS { ?theme skos:narrower ?narrowerTheme }
+              }
+
+              OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
+              OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
+
+            } GROUP BY ?output ?date ?type ?abstract ?title ?citation
+            ORDER BY DESC(?date)
+            LIMIT #{limit}
+          SPARQL
+        end
+
+        def limit
+          (options[:limit] || DEFAULT_LIMIT).tap do |check_is_integer|
+            Integer(check_is_integer)
+          end
         end
       end
     end

--- a/lib/tasks/list/mappings.rake
+++ b/lib/tasks/list/mappings.rake
@@ -4,16 +4,14 @@ require 'dfid-transition/transform/mappings'
 
 namespace :list do
   desc 'List transition mappings for old URLs'
-  task :mappings do
-    module DfidTransition
-      output_query = Extract::Query::Outputs.new
+  task :mappings, [:limit] do |_t, args|
+    output_query = DfidTransition::Extract::Query::Outputs.new(limit: args[:limit])
 
-      mappings = Transform::Mappings.new(
-        Services.attachment_index,
-        output_query.solutions
-      )
+    mappings = DfidTransition::Transform::Mappings.new(
+      DfidTransition::Services.attachment_index,
+      output_query.solutions
+    )
 
-      mappings.dump_csv
-    end
+    mappings.dump_csv
   end
 end

--- a/lib/tasks/load/attachments.rake
+++ b/lib/tasks/load/attachments.rake
@@ -4,16 +4,20 @@ require 'dfid-transition/services'
 
 namespace :load do
   desc 'Load DFID attachments with attachment URIs from the SPARQL endpoint'
-  task :attachments do
-    module DfidTransition
-      output_solutions = Extract::Query::Outputs.new.solutions
+  task :attachments, [:limit] do |_t, args|
+    logger = Logger.new(STDERR)
 
-      attachments_loader = Load::Attachments.new(
-        Services.asset_manager,
-        output_solutions
-      )
+    query = DfidTransition::Extract::Query::Outputs.new(limit: args[:limit])
 
-      attachments_loader.run
-    end
+    logger.info "Requesting #{query.limit} documents' worth of attachments"
+    output_solutions = query.solutions
+
+    attachments_loader = DfidTransition::Load::Attachments.new(
+      DfidTransition::Services.asset_manager,
+      output_solutions,
+      logger: logger
+    )
+
+    attachments_loader.run
   end
 end

--- a/lib/tasks/load/outputs.rake
+++ b/lib/tasks/load/outputs.rake
@@ -4,17 +4,20 @@ require 'dfid-transition/services'
 
 namespace :load do
   desc 'Load DFID outputs with results from the SPARQL endpoint'
-  task :outputs do
-    module DfidTransition
-      output_solutions = Extract::Query::Outputs.new.solutions
-      loader = Load::Outputs.new(
-        Services.publishing_api,
-        Services.rummager,
-        Services.asset_manager,
-        Services.attachment_index,
-        output_solutions
-      )
-      loader.run
-    end
+  task :outputs, [:limit] do |_t, args|
+    logger   = Logger.new(STDERR)
+    services = DfidTransition::Services
+
+    outputs  = DfidTransition::Extract::Query::Outputs.new(limit: args[:limit])
+
+    loader = DfidTransition::Load::Outputs.new(
+      services.publishing_api,
+      services.rummager,
+      services.asset_manager,
+      services.attachment_index,
+      outputs.solutions,
+      logger: logger
+    )
+    loader.run
   end
 end

--- a/spec/lib/dfid-transition/extract/query/outputs_spec.rb
+++ b/spec/lib/dfid-transition/extract/query/outputs_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'dfid-transition/extract/query/outputs'
+
+Outputs = DfidTransition::Extract::Query::Outputs
+
+describe Outputs do
+  subject(:outputs) { Outputs.new(options) }
+
+  describe '#query' do
+    context "No no, no no no no, no no no no, no no, there's no :limit" do
+      let(:options) { {} }
+
+      it 'defaults to the DEFAULT_LIMIT constant' do
+        expect(outputs.query).to include("LIMIT #{Outputs::DEFAULT_LIMIT}")
+      end
+    end
+
+    context "Yes, yes, yes yes yes yes, yes yes yes yes, yes yes, there's a :limit" do
+      context 'a string, as from a rake task' do
+        let(:options) { { limit: '2000' } }
+
+        it 'uses the limit sent' do
+          expect(outputs.query).to include("LIMIT 2000")
+        end
+      end
+
+      context 'a numeric, as from irb' do
+        let(:options) { { limit: 2000 } }
+
+        it 'uses the limit sent' do
+          expect(outputs.query).to include("LIMIT 2000")
+        end
+      end
+
+      context 'unsanitary input (not an integer)' do
+        context 'injection' do
+          let(:options) { { limit: '; Little Bobby Tables; DROP TABLE students;' } }
+
+          it 'raises an ArgumentError' do
+            expect { outputs.query }.to raise_error(ArgumentError, /invalid value for Integer\(\)/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/dfid-transition/patch/govuk_content_schemas/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/govuk_content_schemas/themes_spec.rb
@@ -32,7 +32,7 @@ describe DfidTransition::Patch::GovukContentSchemas::Themes do
     before do
       allow(patch).to receive(:themes_query).and_return(
         DfidTransition::Extract::Query::Themes.new(
-          SPARQL::Client.new(r4d_skos_theme_repo)
+          client: SPARQL::Client.new(r4d_skos_theme_repo)
         )
       )
 

--- a/spec/lib/dfid-transition/patch/rummager/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/rummager/themes_spec.rb
@@ -32,7 +32,7 @@ describe DfidTransition::Patch::Rummager::Themes do
       before do
         allow(patcher).to receive(:themes_query).and_return(
           DfidTransition::Extract::Query::Themes.new(
-            SPARQL::Client.new(r4d_skos_theme_repo)
+            client: SPARQL::Client.new(r4d_skos_theme_repo)
           )
         )
 

--- a/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
+++ b/spec/lib/dfid-transition/patch/specialist_publisher/themes_spec.rb
@@ -17,7 +17,7 @@ describe DfidTransition::Patch::SpecialistPublisher::Themes do
     before do
       allow(patch).to receive(:themes_query).and_return(
         DfidTransition::Extract::Query::Themes.new(
-          SPARQL::Client.new(r4d_skos_theme_repo)
+          client: SPARQL::Client.new(r4d_skos_theme_repo)
         )
       )
 


### PR DESCRIPTION
For each of `load:outputs`, `load:attachments` and `list:mappings`, allow a `:limit` parameter that sets the number of outputs for which the task should apply.

Rearrange things internally so that `Query.client` can be set by options rather than the first parameter in `Query.new`.
