### PR TITLE
Don't blow up on FTP URLs

### DIFF
--- a/lib/dfid-transition/transform/attachment.rb
+++ b/lib/dfid-transition/transform/attachment.rb
@@ -12,7 +12,9 @@ module DfidTransition
 
       def initialize(original_url)
         @original_url = URI(original_url)
-        raise ArgumentError, "expected a URL, got #{original_url}" unless @original_url.is_a?(URI::HTTP)
+        unless @original_url.is_a?(URI::HTTP) || @original_url.is_a?(URI::FTP)
+          raise ArgumentError, "expected an HTTP or FTP URL, got #{original_url}"
+        end
       end
 
       def content_id
@@ -48,7 +50,7 @@ module DfidTransition
       end
 
       def hosted_at_r4d?
-        original_url.host == 'r4d.dfid.gov.uk'
+        original_url.host == 'r4d.dfid.gov.uk' && original_url.scheme == 'http'
       end
 
       def filename

--- a/spec/lib/dfid-transition/transform/attachment_spec.rb
+++ b/spec/lib/dfid-transition/transform/attachment_spec.rb
@@ -9,8 +9,8 @@ module DfidTransition::Transform
       it 'fails given completely the wrong type' do
         expect { Attachment.new(1) }.to raise_error(ArgumentError, /expected URI object or URI string/)
       end
-      it 'fails given a URI that isn\'t a URL' do
-        expect { Attachment.new('some:uri') }.to raise_error(ArgumentError, /expected a URL/)
+      it 'fails given a URI that isn\'t a URL in our schemes' do
+        expect { Attachment.new('some:uri') }.to raise_error(ArgumentError, /expected an HTTP or FTP URL/)
       end
     end
 
@@ -117,6 +117,14 @@ module DfidTransition::Transform
           expect(attachment.file).to be_a(File)
           expect(attachment.file.read).to eql(pdf_content)
         end
+      end
+    end
+
+    context 'given any FTP URL' do
+      let(:original_url) { 'ftp://r4d.dfid.gov.uk/some/file.pdf' }
+
+      it 'is always assumed offsite (in reality, no r4d FTP)' do
+        expect(attachment).not_to be_hosted_at_r4d
       end
     end
 


### PR DESCRIPTION
Instead, always treat them as external (there aren't any onsite FTP
URLs).
