### PR TITLE
Only delete files that exist

### DIFF
--- a/lib/dfid-transition/extract/download/attachment.rb
+++ b/lib/dfid-transition/extract/download/attachment.rb
@@ -19,7 +19,7 @@ module DfidTransition
             asset_response = attachment.save_to(asset_manager)
             attachment_index.put(url, asset_response)
           ensure
-            File.delete(attachment.tmp_path)
+            File.delete(attachment.tmp_path) if File.exist?(attachment.tmp_path)
           end
         end
 

--- a/spec/lib/dfid-transition/extract/download/attachment_spec.rb
+++ b/spec/lib/dfid-transition/extract/download/attachment_spec.rb
@@ -37,6 +37,7 @@ describe DfidTransition::Extract::Download::Attachment do
         allow(attachment_index).to receive(:get).with(original_url).and_return(nil)
         stub_request(:get, original_url).to_return(status: 200, body: 'Some content')
         allow(asset_manager).to receive(:create_asset).and_return(asset_response)
+        allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:delete)
 
         subject.perform(original_url)


### PR DESCRIPTION
Unreasonable number of ENOENTs in sidekiq. Not sure why there might
be a race to delete, but this is an effective and safe fix without
losing time to a complex race condition.
