### PR TITLE
Titles for slugs

### DIFF
--- a/lib/dfid-transition/extract/query/duplicate_titles.rb
+++ b/lib/dfid-transition/extract/query/duplicate_titles.rb
@@ -1,0 +1,26 @@
+require 'dfid-transition/extract/query/base'
+
+module DfidTransition
+  module Extract
+    module Query
+      class DuplicateTitles < Base
+        QUERY = <<-SPARQL.freeze
+          PREFIX dcterms: <http://purl.org/dc/terms/>
+          PREFIX ont:     <http://purl.org/ontology/bibo/>
+
+          SELECT ?title (COUNT(DISTINCT ?output) AS ?outputCount)
+          WHERE {
+            ?output a ont:Article ;
+                    dcterms:title ?title .
+          } GROUP BY ?title
+          HAVING(COUNT(DISTINCT ?output) > 1)
+          ORDER BY DESC(?outputCount)
+        SPARQL
+
+        def query
+          QUERY
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/load/output.rb
+++ b/lib/dfid-transition/load/output.rb
@@ -17,6 +17,7 @@ module DfidTransition
         solution = solutions.first
 
         self.doc = DfidTransition::Transform::Document.new(solution)
+        doc.disambiguate! if slug_collision_index.collides?(doc.slug)
 
         unless all_assets_available?
           logger.warn("One or more assets missing for #{doc.original_url}")
@@ -84,6 +85,10 @@ module DfidTransition
 
       def publishing_api
         Services.publishing_api
+      end
+
+      def slug_collision_index
+        raise NotImplementedError
       end
     end
   end

--- a/lib/dfid-transition/load/output.rb
+++ b/lib/dfid-transition/load/output.rb
@@ -60,7 +60,7 @@ module DfidTransition
           publishing_api.patch_links(doc.content_id, doc.links)
           publishing_api.publish(doc.content_id, update_type)
           logger.info "Published #{doc.title} at "\
-              "http://www.dev.gov.uk/dfid-research-outputs/#{doc.original_id}"
+              "http://www.dev.gov.uk#{doc.base_path}"
         rescue => e
           logger.error(e)
         end

--- a/lib/dfid-transition/load/output.rb
+++ b/lib/dfid-transition/load/output.rb
@@ -88,7 +88,7 @@ module DfidTransition
       end
 
       def slug_collision_index
-        raise NotImplementedError
+        Services.slug_collision_index
       end
     end
   end

--- a/lib/dfid-transition/load/outputs.rb
+++ b/lib/dfid-transition/load/outputs.rb
@@ -63,7 +63,7 @@ module DfidTransition
           publishing_api.patch_links(doc.content_id, doc.links)
           publishing_api.publish(doc.content_id, update_type)
           logger.info "Published #{doc.title} at "\
-              "http://www.dev.gov.uk/dfid-research-outputs/#{doc.original_id}"
+              "http://www.dev.gov.uk#{doc.base_path}"
         rescue => e
           logger.error(e)
         end

--- a/lib/dfid-transition/load/slug_collisions.rb
+++ b/lib/dfid-transition/load/slug_collisions.rb
@@ -1,0 +1,24 @@
+require 'dfid-transition/transform/document'
+
+module DfidTransition
+  module Load
+    class SlugCollisions
+      def initialize(slug_collision_index, solutions, logger: STDERR)
+        @slug_collision_index = slug_collision_index
+        @solutions = solutions
+        @logger = logger
+      end
+
+      def run
+        loaded = 0
+        @solutions.each do |solution|
+          slug = DfidTransition::Transform::Document.new(solution).slug
+          @slug_collision_index.put(slug)
+          loaded += 1
+        end
+
+        @logger.info "#{loaded} collisions loaded"
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/load/slug_collisions.rb
+++ b/lib/dfid-transition/load/slug_collisions.rb
@@ -14,7 +14,7 @@ module DfidTransition
         @solutions.each do |solution|
           slug = DfidTransition::Transform::Document.new(solution).slug
           @slug_collision_index.put(slug)
-          loaded += 1
+          loaded += solution[:outputCount].to_i
         end
 
         @logger.info "#{loaded} collisions loaded"

--- a/lib/dfid-transition/services.rb
+++ b/lib/dfid-transition/services.rb
@@ -2,6 +2,7 @@ require 'gds_api/publishing_api_v2'
 require 'gds_api/asset_manager'
 require 'gds_api/rummager'
 require 'dfid-transition/services/attachment_index'
+require 'dfid-transition/services/slug_collision_index'
 
 module DfidTransition
   module Services
@@ -25,6 +26,10 @@ module DfidTransition
 
     def self.attachment_index
       @attachment_index ||= AttachmentIndex.new(redis)
+    end
+
+    def self.slug_collision_index
+      @slug_collision_index ||= SlugCollisionIndex.new(redis)
     end
 
     def self.redis

--- a/lib/dfid-transition/services/slug_collision_index.rb
+++ b/lib/dfid-transition/services/slug_collision_index.rb
@@ -1,0 +1,28 @@
+require 'dfid-transition/services'
+
+module DfidTransition
+  module Services
+    ##
+    # Concerns: allows us to look up slug collisions by original_url
+    #
+    class SlugCollisionIndex
+      attr_reader :redis
+
+      def initialize(redis)
+        @redis = redis
+      end
+
+      SLUG_COLLISIONS_SET = 'slug-collisions'.freeze
+      SLUG_COLLISIONS_KEY_PREFIX = 'slug-collisions:for:'.freeze
+
+      def collides?(slug)
+        false
+      end
+    private
+
+      def slug_collision_key(original_url)
+        "attachment:#{original_url}"
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/services/slug_collision_index.rb
+++ b/lib/dfid-transition/services/slug_collision_index.rb
@@ -13,15 +13,13 @@ module DfidTransition
       end
 
       SLUG_COLLISIONS_SET = 'slug-collisions'.freeze
-      SLUG_COLLISIONS_KEY_PREFIX = 'slug-collisions:for:'.freeze
+
+      def put(slug)
+        @redis.sadd(SLUG_COLLISIONS_SET, slug)
+      end
 
       def collides?(slug)
-        false
-      end
-    private
-
-      def slug_collision_key(original_url)
-        "attachment:#{original_url}"
+        @redis.sismember(SLUG_COLLISIONS_SET, slug)
       end
     end
   end

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -49,7 +49,7 @@ module DfidTransition
       end
 
       def slug
-        title.parameterize
+        @slug || title.parameterize
       end
 
       def summary
@@ -57,7 +57,14 @@ module DfidTransition
       end
 
       def base_path
-        "/dfid-research-outputs/#{original_id}"
+        "/dfid-research-outputs/#{slug}"
+      end
+
+      ##
+      # Assert that there will be a collision, so make the slug and
+      # hence the base_path unique using the ID space of the old document
+      def disambiguate!
+        @slug = "#{title.parameterize}-#{original_id}"
       end
 
       def metadata

--- a/lib/dfid-transition/transform/document.rb
+++ b/lib/dfid-transition/transform/document.rb
@@ -5,6 +5,7 @@ require 'dfid-transition/transform/html'
 require 'dfid-transition/transform/attachment'
 require 'dfid-transition/transform/themes'
 require 'active_support/core_ext/string/strip'
+require 'active_support/core_ext/string/inflections'
 require 'erubis'
 
 module DfidTransition
@@ -45,6 +46,10 @@ module DfidTransition
         title = solution[:title].to_s
         unescaped_title = Html.unescape_three_times(title)
         unescaped_title.strip
+      end
+
+      def slug
+        title.parameterize
       end
 
       def summary

--- a/lib/dfid-transition/transform/mappings.rb
+++ b/lib/dfid-transition/transform/mappings.rb
@@ -22,7 +22,7 @@ module DfidTransition
         @solutions.each do |solution|
           doc = DfidTransition::Transform::Document.new(solution)
 
-          @output.puts "#{doc.original_url},https://gov.uk/dfid-research-outputs/#{doc.original_id}\n"
+          @output.puts "#{doc.original_url},https://gov.uk#{doc.base_path}\n"
 
           doc.downloads.each do |download|
             existing_details = @attachment_index.get(download.original_url.to_s)

--- a/lib/dfid-transition/transform/mappings.rb
+++ b/lib/dfid-transition/transform/mappings.rb
@@ -3,13 +3,15 @@ require 'dfid-transition/transform/document'
 module DfidTransition
   module Transform
     ##
-    # Given a set of output solutions with URIs and an attachment index,
+    # Given a set of output solutions with URIs, an attachment index,
+    # and a slug collision index
     # #dump_csv will output a transition-compatible CSV to $stdout
     # (or `output_to`, if supplied)
     #
     class Mappings
-      def initialize(attachment_index, solutions, output_to: $stdout)
+      def initialize(attachment_index, slug_collision_index, solutions, output_to: $stdout)
         @attachment_index = attachment_index
+        @slug_collision_index = slug_collision_index
         @solutions = solutions
         @output = output_to
       end
@@ -21,6 +23,7 @@ module DfidTransition
 
         @solutions.each do |solution|
           doc = DfidTransition::Transform::Document.new(solution)
+          doc.disambiguate! if @slug_collision_index.collides?(doc.slug)
 
           @output.puts "#{doc.original_url},https://gov.uk#{doc.base_path}\n"
 

--- a/lib/tasks/list/mappings.rake
+++ b/lib/tasks/list/mappings.rake
@@ -9,6 +9,7 @@ namespace :list do
 
     mappings = DfidTransition::Transform::Mappings.new(
       DfidTransition::Services.attachment_index,
+      DfidTransition::Services.slug_collision_index,
       output_query.solutions
     )
 

--- a/lib/tasks/load/slug_collision_index.rake
+++ b/lib/tasks/load/slug_collision_index.rake
@@ -1,0 +1,20 @@
+require 'dfid-transition/extract/query/base_path_dupes'
+require 'dfid-transition/load/slug_collisions'
+require 'dfid-transition/services'
+
+namespace :load do
+  desc 'Load the slug collision index'
+  task :collisions do
+    logger   = Logger.new(STDERR)
+    services = DfidTransition::Services
+
+    collisions_query = DfidTransition::Extract::Query::BasePathDupes.new
+
+    loader = DfidTransition::Load::SlugCollisions.new(
+      services.slug_collision_index,
+      collisions_query.solutions,
+      logger: logger
+    )
+    loader.run
+  end
+end

--- a/lib/tasks/load/slug_collision_index.rake
+++ b/lib/tasks/load/slug_collision_index.rake
@@ -1,4 +1,4 @@
-require 'dfid-transition/extract/query/base_path_dupes'
+require 'dfid-transition/extract/query/duplicate_titles'
 require 'dfid-transition/load/slug_collisions'
 require 'dfid-transition/services'
 
@@ -8,7 +8,7 @@ namespace :load do
     logger   = Logger.new(STDERR)
     services = DfidTransition::Services
 
-    collisions_query = DfidTransition::Extract::Query::BasePathDupes.new
+    collisions_query = DfidTransition::Extract::Query::DuplicateTitles.new
 
     loader = DfidTransition::Load::SlugCollisions.new(
       services.slug_collision_index,

--- a/spec/lib/dfid-transition/load/output_spec.rb
+++ b/spec/lib/dfid-transition/load/output_spec.rb
@@ -7,7 +7,7 @@ describe DfidTransition::Load::Output do
   let(:publishing_api)       { spy('publishing-api') }
   let(:rummager)             { spy('rummager') }
   let(:attachment_index)     { spy('attachment_index') }
-  let(:slug_collision_index) { spy('attachment_index') }
+  let(:slug_collision_index) { spy('slug_collision_index') }
   let(:solutions)            { [] }
   let(:logger)               { double('Logger').as_null_object }
 

--- a/spec/lib/dfid-transition/load/slug_collisions_spec.rb
+++ b/spec/lib/dfid-transition/load/slug_collisions_spec.rb
@@ -11,8 +11,8 @@ describe DfidTransition::Load::SlugCollisions do
 
     let(:solutions) do
       [
-        { output: uri('http://linked-development.org/r4d/output/5050/'), title: 'A slug' },
-        { output: uri('http://linked-development.org/r4d/output/5051/'), title: 'Another slug' }
+        { title: literal('A slug'), outputCount: integer(2) },
+        { title: literal('Another slug'), outputCount: integer(2) }
       ]
     end
 
@@ -31,7 +31,7 @@ describe DfidTransition::Load::SlugCollisions do
     end
 
     it 'tells us how many' do
-      expect(logger).to have_received(:info).with('2 collisions loaded')
+      expect(logger).to have_received(:info).with('4 collisions loaded')
     end
   end
 end

--- a/spec/lib/dfid-transition/load/slug_collisions_spec.rb
+++ b/spec/lib/dfid-transition/load/slug_collisions_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'dfid-transition/load/slug_collisions'
+
+describe DfidTransition::Load::SlugCollisions do
+  describe '#run' do
+    include RDFDoubles
+
+    let(:collision_index) { spy 'DfidTransition::Services::CollisionIndex' }
+    let(:logger)          { double('Logger').as_null_object }
+
+
+    let(:solutions) do
+      [
+        { output: uri('http://linked-development.org/r4d/output/5050/'), title: 'A slug' },
+        { output: uri('http://linked-development.org/r4d/output/5051/'), title: 'Another slug' }
+      ]
+    end
+
+    subject(:loader) do
+      DfidTransition::Load::SlugCollisions.new(
+        collision_index, solutions, logger: logger)
+    end
+
+    before do
+      loader.run
+    end
+
+    it 'has loaded all the slugs' do
+      expect(collision_index).to have_received(:put).with('a-slug')
+      expect(collision_index).to have_received(:put).with('another-slug')
+    end
+
+    it 'tells us how many' do
+      expect(logger).to have_received(:info).with('2 collisions loaded')
+    end
+  end
+end

--- a/spec/lib/dfid-transition/services/slug_collision_index_spec.rb
+++ b/spec/lib/dfid-transition/services/slug_collision_index_spec.rb
@@ -19,7 +19,7 @@ describe DfidTransition::Services::SlugCollisionIndex do
 
     context 'is in the index' do
       before { slug_collision_index.put(slug) }
-      it     { is_expected.to be true}
+      it     { is_expected.to be true }
     end
   end
 end

--- a/spec/lib/dfid-transition/services/slug_collision_index_spec.rb
+++ b/spec/lib/dfid-transition/services/slug_collision_index_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'dfid-transition/services/slug_collision_index'
+require 'mock_redis'
+
+describe DfidTransition::Services::SlugCollisionIndex do
+  SlugCollisionIndex = DfidTransition::Services::SlugCollisionIndex
+
+  let(:redis)                { MockRedis.new }
+  let(:slug_collision_index) { SlugCollisionIndex.new(redis) }
+
+  describe '#collides?' do
+    let(:slug) { 'example-slug' }
+
+    subject { slug_collision_index.collides?(slug) }
+
+    context 'no item in the index' do
+      it { is_expected.to be false }
+    end
+
+    context 'is in the index' do
+      before { slug_collision_index.put(slug) }
+      it     { is_expected.to be true}
+    end
+  end
+end

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -81,8 +81,18 @@ module DfidTransition::Transform
         expect(doc.original_id).to eql('5050')
       end
 
-      it 'has a base_path' do
-        expect(doc.base_path).to eql('/dfid-research-outputs/5050')
+      it 'has a base_path that corresponds to the title' do
+        expect(doc.base_path).to eql('/dfid-research-outputs/and-then-he-switched-off-the-phone-mobile-phones')
+      end
+
+      describe '#disambiguate_slug!' do
+        it 'appends the original_id' do
+          expect { doc.disambiguate! }.to change { doc.slug }.from(
+            'and-then-he-switched-off-the-phone-mobile-phones'
+          ).to (
+            'and-then-he-switched-off-the-phone-mobile-phones-5050'
+          )
+        end
       end
 
       it 'has a public_updated_at' do

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -89,9 +89,8 @@ module DfidTransition::Transform
         it 'appends the original_id' do
           expect { doc.disambiguate! }.to change { doc.slug }.from(
             'and-then-he-switched-off-the-phone-mobile-phones'
-          ).to (
+          ).to \
             'and-then-he-switched-off-the-phone-mobile-phones-5050'
-          )
         end
       end
 

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -69,6 +69,10 @@ module DfidTransition::Transform
           '‘And Then He Switched off the Phone’: Mobile Phones ...')
       end
 
+      it 'has a slug' do
+        expect(doc.slug).to eql('and-then-he-switched-off-the-phone-mobile-phones')
+      end
+
       it 'always has an empty summary' do
         expect(doc.summary).to be_empty
       end

--- a/spec/support/rdf_doubles.rb
+++ b/spec/support/rdf_doubles.rb
@@ -17,6 +17,12 @@ module RDFDoubles
     end
   end
 
+  def integer(value)
+    double('RDF::Literal::Integer').tap do |integer|
+      allow(integer).to receive(:to_i).and_return(value)
+    end
+  end
+
   class Solution
     def initialize(value_hash)
       @value_hash = value_hash


### PR DESCRIPTION
Publish documents under slug titles.

When a document would collide with another output with the same name, append the `original_id` of the output to that document to make it unique.
