### PR TITLE
Transform bold headers to h3

### DIFF
--- a/lib/dfid-transition/transform/html.rb
+++ b/lib/dfid-transition/transform/html.rb
@@ -14,10 +14,28 @@ module DfidTransition
       end
 
       def self.to_markdown(html)
-        corrected_html = Nokogiri::HTML.fragment(html).to_s
+        corrected_html = expand_h3s(html)
 
         kramdown_tree, _warnings = Kramdown::Parser::Html.parse(corrected_html)
         Kramdown::Converter::Kramdown.convert(kramdown_tree).first
+      end
+
+      KNOWN_HEADERS = ['Query', 'Summary', 'Key Findings', 'Overview'].map { |h| Regexp.new(h) }
+
+      def self.expand_h3s(frag)
+        frag = Nokogiri::HTML.fragment(frag) unless frag.is_a?(Nokogiri::HTML::DocumentFragment)
+
+        header_nodes = frag.css('b,strong').select do |f|
+          KNOWN_HEADERS.any? { |known_header| f.text =~ known_header }
+        end
+
+        header_nodes.each do |node|
+          node.name = 'h3'
+          node.content = node.content.sub(':', '')
+          node.add_previous_sibling('<br/><br/>')
+          node.next_sibling.content = node.next_sibling.content.sub(/^\s*/, '')
+        end
+        frag.to_s
       end
     end
   end

--- a/lib/dfid-transition/transform/html.rb
+++ b/lib/dfid-transition/transform/html.rb
@@ -20,14 +20,12 @@ module DfidTransition
         Kramdown::Converter::Kramdown.convert(kramdown_tree).first
       end
 
-      KNOWN_HEADERS = ['Query', 'Summary', 'Key Findings', 'Overview'].map { |h| Regexp.new(h) }
+      HEADER_ENDS_WITH_COLON = /[a-z]{2,}:\s*$/
 
       def self.expand_h3s(frag)
         frag = Nokogiri::HTML.fragment(frag) unless frag.is_a?(Nokogiri::HTML::DocumentFragment)
 
-        header_nodes = frag.css('b,strong').select do |f|
-          KNOWN_HEADERS.any? { |known_header| f.text =~ known_header }
-        end
+        header_nodes = frag.css('b,strong').select { |f| f.content =~ HEADER_ENDS_WITH_COLON }
 
         header_nodes.each do |node|
           node.name = 'h3'

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -257,6 +257,25 @@ module DfidTransition::Transform
             end
           end
         end
+
+        context 'the abstract has Query: and Summary:' do
+          before do
+            solution_hash[:abstract] = literal(
+              <<-TEXT
+                This is a piece of abstract.
+
+                <b>Query:</b> Something that's a query
+
+                <strong>Summary:</strong> Something that's a summary.
+              TEXT
+            )
+          end
+
+          it 'expands them to h3' do
+            expect(body).to match(/^### Query\n\nSomething/)
+            expect(body).to match(/^### Summary\n\nSomething/m)
+          end
+        end
       end
 
       describe '#creators' do

--- a/spec/lib/dfid-transition/transform/html_spec.rb
+++ b/spec/lib/dfid-transition/transform/html_spec.rb
@@ -93,7 +93,7 @@ module DfidTransition::Transform
         Html.expand_h3s(abstract)
       end
 
-      context 'Query and summary are b or strong' do
+      context 'Query, Summary, Key findings are b or strong' do
         let(:abstract) do
           <<-TEXT
             This is a piece of abstract.
@@ -101,12 +101,18 @@ module DfidTransition::Transform
             <b>Query:</b> Something that's a query
 
             <strong>Summary:</strong> Something that's a summary.
+
+            <b>Key Findings:</b> These are key findings
           TEXT
         end
 
         it 'expands query and summary to h3' do
           expect(result).to include('<h3>Query</h3>')
           expect(result).to include('<h3>Summary</h3>')
+        end
+
+        it 'expands key findings to h3' do
+          expect(result).to include('<h3>Key Findings</h3>')
         end
       end
     end

--- a/spec/lib/dfid-transition/transform/html_spec.rb
+++ b/spec/lib/dfid-transition/transform/html_spec.rb
@@ -87,5 +87,28 @@ module DfidTransition::Transform
         end
       end
     end
+
+    describe '.expand_h3s' do
+      subject(:result) do
+        Html.expand_h3s(abstract)
+      end
+
+      context 'Query and summary are b or strong' do
+        let(:abstract) do
+          <<-TEXT
+            This is a piece of abstract.
+
+            <b>Query:</b> Something that's a query
+
+            <strong>Summary:</strong> Something that's a summary.
+          TEXT
+        end
+
+        it 'expands query and summary to h3' do
+          expect(result).to include('<h3>Query</h3>')
+          expect(result).to include('<h3>Summary</h3>')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Query, Summary, Overview, Key Findings – all should be `h3`. Process
with `Nokogiri::HTML.fragment`, change the node type, remove the colon
and add `<br/>`s above.
