### PR TITLE
Remove web: from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-web: bundle exec rackup -p 3124
 worker: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
We aren't ever going to start it ourselves via `bowl`. At time of commit this is
 started by unicorn-herder due to an app_type of 'rack' in
 govuk-puppet. It's our intention to start it as part of
 sidekiq-monitoring, though, which has its own Procfile that does a
 simple single-process rackup.
