### PR TITLE
Add enqueue:outputs_with_malformed_lists task

### DIFF
--- a/lib/dfid-transition/extract/query/abstracts_with_lists.rb
+++ b/lib/dfid-transition/extract/query/abstracts_with_lists.rb
@@ -1,0 +1,51 @@
+require 'dfid-transition/extract/query/base'
+
+module DfidTransition
+  module Extract
+    module Query
+      class AbstractsWithLists < Base
+        def query
+          <<-SPARQL
+            PREFIX dcterms: <http://purl.org/dc/terms/>
+            PREFIX geo:     <http://www.fao.org/countryprofiles/geoinfo/geopolitical/resource/>
+            PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+            PREFIX bibo:    <http://purl.org/ontology/bibo/>
+            PREFIX status:  <http://purl.org/bibo/status/>
+            PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+            SELECT DISTINCT ?output ?date ?type ?abstract ?title ?citation
+              (EXISTS { ?output bibo:DocumentStatus status:peerReviewed } AS ?peerReviewed)
+              (GROUP_CONCAT(DISTINCT(?creator); separator = '|') AS ?creators)
+              (GROUP_CONCAT(DISTINCT(?codeISO2)) AS ?countryCodes)
+              (GROUP_CONCAT(DISTINCT(?uri)) AS ?uris)
+              (GROUP_CONCAT(DISTINCT(?theme)) AS ?themes)
+            WHERE {
+              ?output a bibo:Article ;
+                      dcterms:type ?type ;
+                      dcterms:title ?title ;
+                      dcterms:abstract ?abstract ;
+                      dcterms:bibliographicCitation ?citation ;
+                      dcterms:date ?date ;
+                      dcterms:subject ?theme .
+
+              { ?output bibo:uri ?uri } UNION { ?output dcterms:uri ?uri }
+
+              FILTER ( ?type != 'text' )
+              FILTER(regex(str(?abstract), '&amp;lt;li'))
+
+              {
+                ?theme skos:inScheme <http://r4d.dfid.gov.uk/rdf/skos/Themes>
+                FILTER EXISTS { ?theme skos:narrower ?narrowerTheme }
+              }
+
+              OPTIONAL { ?output dcterms:coverage/geo:codeISO2 ?codeISO2 }
+              OPTIONAL { ?output dcterms:creator/foaf:name     ?creator }
+
+            } GROUP BY ?output ?date ?type ?abstract ?title ?citation
+            ORDER BY DESC(?date)
+          SPARQL
+        end
+      end
+    end
+  end
+end

--- a/lib/dfid-transition/transform/html.rb
+++ b/lib/dfid-transition/transform/html.rb
@@ -17,8 +17,10 @@ module DfidTransition
       def self.to_markdown(html)
         fragment = Nokogiri::HTML.fragment(html)
         corrected_html =
-          replace_linked_development_hrefs(
-            expand_h3s(fragment)
+          correct_malformed_lists(
+            replace_linked_development_hrefs(
+              expand_h3s(fragment)
+            )
           ).to_s
 
         kramdown_tree, _warnings = Kramdown::Parser::Html.parse(corrected_html)
@@ -36,6 +38,14 @@ module DfidTransition
       end
 
       HEADER_ENDS_WITH_COLON = /[a-z]{2,}:\s*$/
+
+      def self.correct_malformed_lists(frag)
+        frag = Nokogiri::HTML.fragment(frag) unless frag.is_a?(Nokogiri::HTML::DocumentFragment)
+        frag.css('ol, ul').each do |list|
+          list.add_previous_sibling('<br /><br />')
+        end
+        frag
+      end
 
       def self.expand_h3s(frag)
         frag = Nokogiri::HTML.fragment(frag) unless frag.is_a?(Nokogiri::HTML::DocumentFragment)

--- a/lib/dfid-transition/transform/malformed_list_tester.rb
+++ b/lib/dfid-transition/transform/malformed_list_tester.rb
@@ -1,0 +1,45 @@
+require 'dfid-transition/transform/html'
+
+module DfidTransition
+  module Transform
+    class MalformedListTester
+      Html = DfidTransition::Transform::Html
+
+      attr_reader :solution
+
+      def initialize(solution)
+        @solution = solution
+      end
+
+      def has_malformed_ul?
+        abstract.match(/\* /) && !abstract.match(/\n\n\* /)
+      end
+
+      def has_malformed_ol?
+        abstract.match(/1\. /) && abstract.match(/2\. /) && !abstract.match(/\n\n1\. /)
+      end
+
+      def has_malformed_list?
+        has_malformed_ol? || has_malformed_ul?
+      end
+
+      def abstract
+        @abstract ||= self.to_markdown(
+          Html.unescape_three_times(
+            Html.fix_encoding_errors(
+              solution[:abstract].to_s
+            )
+          )
+        )
+      end
+
+      def to_markdown(html)
+        fragment = Nokogiri::HTML.fragment(html)
+        corrected_html = fragment.to_s
+
+        kramdown_tree, _warnings = Kramdown::Parser::Html.parse(corrected_html)
+        Kramdown::Converter::Kramdown.convert(kramdown_tree).first
+      end
+    end
+  end
+end

--- a/lib/tasks/enqueue/outputs_with_malformed_lists.rake
+++ b/lib/tasks/enqueue/outputs_with_malformed_lists.rake
@@ -1,0 +1,20 @@
+require 'dfid-transition/extract/query/abstracts_with_lists'
+require 'dfid-transition/transform/malformed_list_tester'
+require 'dfid-transition/enqueue/outputs'
+
+namespace :enqueue do
+  desc 'Enqueue outputs that have lists that might be malformed'
+  task :outputs_with_malformed_lists do
+    logger = Logger.new(STDERR)
+
+    outputs_with_lists = DfidTransition::Extract::Query::AbstractsWithLists.new.solutions
+    bad_outputs = outputs_with_lists.to_a.select do |output|
+      DfidTransition::Transform::MalformedListTester.new(output).has_malformed_list?
+    end
+
+    logger.info "Requesting outputs with lists"
+
+    outputs_loader = DfidTransition::Enqueue::Outputs.new(bad_outputs, logger: logger)
+    outputs_loader.run
+  end
+end

--- a/lib/tasks/list/malformed_lists.rake
+++ b/lib/tasks/list/malformed_lists.rake
@@ -1,0 +1,61 @@
+require 'dfid-transition/extract/query/abstracts_with_lists'
+require 'dfid-transition/transform/document'
+require 'dfid-transition/transform/malformed_list_tester'
+require 'dfid-transition/services'
+
+namespace :list do
+  Html = DfidTransition::Transform::Html
+
+  def final_url(doc, env: 'development')
+    host = case env
+           when 'integration' then 'www-origin.integration.publishing.service.gov.uk'
+           when 'staging' then 'www-origin.staging.publishing.service.gov.uk'
+           when 'development' then 'www.dev.gov.uk'
+           else 'gov.uk'
+           end
+    "http#{env == 'development' ? '' : 's'}://#{host}#{doc.base_path}"
+  end
+
+  desc 'List abstracts with malformed list'
+  task :malformed_list, [:limit, :env] do |_t, args|
+    env = args[:env]
+
+    query = DfidTransition::Extract::Query::AbstractsWithLists.new(limit: args[:limit])
+
+    malformed_list_tests = query.solutions.map do |solution|
+      DfidTransition::Transform::MalformedListTester.new(solution)
+    end
+
+    malformed_list_solutions = malformed_list_tests.select(&:has_malformed_list?).map(&:solution)
+
+    malformed_list_docs = malformed_list_solutions.map do |solution|
+      DfidTransition::Transform::Document.new(solution).tap do |doc|
+        doc.disambiguate! if DfidTransition::Services.slug_collision_index.collides?(doc.slug)
+      end
+    end
+
+    malformed_list_docs.each do |doc|
+      puts "# #{final_url(doc, env: env)}"
+
+      puts "\n## Raw"
+
+      puts doc.solution[:abstract].to_s
+
+      puts "\n## HTML"
+
+      abstract_html = Html.unescape_three_times(
+        Html.fix_encoding_errors(
+          doc.solution[:abstract].to_s
+        )
+      )
+      puts abstract_html
+
+      puts "\n## As markdown"
+      puts doc.abstract
+      puts "\n**********************************************************\n"
+    end
+
+    puts "\n<ul> total: #{malformed_list_tests.count(&:has_malformed_ul?)}"
+    puts "\n<ol> total: #{malformed_list_tests.count(&:has_malformed_ol?)}"
+  end
+end

--- a/spec/lib/dfid-transition/transform/document_spec.rb
+++ b/spec/lib/dfid-transition/transform/document_spec.rb
@@ -397,6 +397,31 @@ module DfidTransition::Transform
               end
             end
           end
+
+          context 'there are malformed lists (without a line-break)' do
+            context 'ul' do
+              let :abstract do
+                <<-BAD_HTML
+                &amp;lt;b&amp;gt;Query:&amp;lt;/b&amp;gt; What is the evidence on:&amp;lt;br/&amp;gt; &amp;lt;ul&amp;gt;&amp;amp;#61623;&amp;lt;li&amp;gt; how best to promote effective national capacities to conduct learning assessments?&amp;lt;/li&amp;gt; &amp;amp;#61623;&amp;lt;li&amp;gt; to what extent participation in international learning assessments has built national capacities to design, implement and make use of national assessments?&amp;lt;/li&amp;gt; &amp;amp;#61623;&amp;lt;li&amp;gt; participation in international learning assessments having an impact on political decisions, policy-making and teaching practices in countries?&amp;lt;/li&amp;gt; &amp;amp;#61623;&amp;lt;li&amp;gt; the consequences of focusing assessment of learning on language (reading), numeracy/maths and science?&amp;lt;/li&amp;gt; &amp;amp;#61623;&amp;lt;li&amp;gt; the circumstances and actions required to ensure learning assessments (both national and country participation in international assessments) promote and secure improvements in learning achievement?&amp;lt;/li&amp;gt; &amp;lt;/ul&amp;gt; &amp;lt;br/&amp;gt;&amp;lt;b&amp;gt;Summary:&amp;lt;/b&amp;gt; This helpdesk report provides a rapid analysis of evidence of the role of large-scale learning assessments (LSEAs) in education systems in low- and middle-income countries. It is divided into five principal sections, each associated with one of the 5 sub-queries set out above. The information and analysis is supplemented by a number of Annexes detailing specific approaches to learning assessment design and implementation. A bibliography is included, with links for resources used. The resources included in this report were identified through a non-systematic desk-based search. A number of experts were also consulted. This report is a rapid response and, as such, it should be treated as a synthesis of the resources and evidence gathered in the assigned time.
+                BAD_HTML
+              end
+
+              it 'Ensures the first items of lists occur after line breaks' do
+                expect(doc.abstract).to match(/\n^\* how best to promote effective national capacities/)
+              end
+            end
+            context 'ol' do
+              let :abstract do
+                <<-BAD_HTML
+                The DFID Crop Protection Programme (CPP) supported a project entitled “Forecasting movements and breeding of the Red-billed Quelea bird in southern Africa and improved control strategies” The project was intended to provide four main outputs: &amp;lt;ol&amp;gt; &amp;lt;li&amp;gt;A desk-based assessment of the environmental impacts of quelea control operations.&amp;lt;/li&amp;gt; &amp;lt;li&amp;gt;A preliminary analysis of the potential for developing a statistical medium term quelea seasonal forecasting model based on sea surface temperature (SST) data and atmospheric indicators.&amp;lt;/li&amp;gt; &amp;lt;li&amp;gt;Increased knowledge of the key relationships between environmental factors and quelea migrations and breeding activities..&amp;lt;/li&amp;gt; &amp;lt;li&amp;gt;A computer-based model for forecasting the timing and geographical distribution of quelea breeding activity in southern Africa.&amp;lt;/li&amp;gt; &amp;lt;/ol&amp;gt; &amp;lt;p&amp;gt; The presentation discussed how involvement with the Information Core for Southern African Migrant Pests (ICOSAMP) project would assist in achieving these objectives, with particular reference to forecasts of breeding by the Red-billed Quelea Quelea quelea lathamii. For each objective, details of achievements to date, needs and future plans were discussed.&amp;lt;/p&amp;gt;
+                BAD_HTML
+              end
+
+              it 'Ensures the first items of lists occur after line breaks' do
+                expect(doc.abstract).to match(/\n^1\.  A desk-based assessment/)
+              end
+            end
+          end
         end
       end
 

--- a/spec/lib/dfid-transition/transform/html_spec.rb
+++ b/spec/lib/dfid-transition/transform/html_spec.rb
@@ -89,17 +89,12 @@ module DfidTransition::Transform
             </ul>
           HTML
         end
-        it {
-          is_expected.to eql(<<-MARKDOWN.strip_heredoc
-            This is para 1
-
-            This is para 2
-
-            * A list item
-
-            MARKDOWN
-          )
-        }
+        it 'has the paras' do
+          expect(markdown).to include("This is para 1\n\nThis is para 2")
+        end
+        it 'has the list' do
+          expect(markdown).to match(/\n\* A list item/)
+        end
       end
 
       context 'there are lists in paragraphs' do


### PR DESCRIPTION
Also add list:malformed_lists, which reports, showing abstracts,
which items look malformed.

enqueue:outputs_with_malformed_lists will take outputs with
apparently malformed lists (some false positives, but these just
republish) and load them for retransformation/republishing.
